### PR TITLE
Tissue vs Background segmentation

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -80,7 +80,7 @@ python run_batch_of_slides.py --task seg --wsi_dir ./wsis --job_dir ./trident_pr
 ## Under the Hood
 
 ### Segmentation
-Segmentation is performed by a [DeepLabV3 model](https://arxiv.org/abs/1706.05587v3) finetuned specifically to segment tissue from background in WSIs. By default, `run_trident.py` segments at 10x magnification. Use `--fast_seg` to segment at 5x magnification, which is faster but may be less accurate. If neither option yields good results, you can manually set `seg_mag` in `processor.run_segmentation_job()` to a higher magnification level. Note that higher magnification levels will be substantially slower.
+Segmentation is performed by a deep learning model. 2 options: HEST segmenter, a [DeepLabV3 model](https://arxiv.org/abs/1706.05587v3) finetuned specifically to segment tissue from background in WSIs (`--segmenter hest`), or GrandQC segmenter, published in [Nat. Comm](https://www.nature.com/articles/s41467-024-54769-y) which can be used with `--segmenter grandqc`. 
 
 ### Patching
 Trident's patching module is deterministic and extracts a set of patch coordinates given a tissue mask. Patches are extracted at a particular size (`patch_size`) and particular magnification (`mag`). Trident will attempt to read the base resolution of the WSI and calculate the appropriate downsample factor to extract patches at the desired magnification. Patches can either be nonoverlapping (`overlap == 0`) or overlapping (`overlap > 0`), where `overlap` refers to the absolute overlap in pixels. Trident keeps all patches that contain at least one pixel of tissue.

--- a/README.md
+++ b/README.md
@@ -166,8 +166,7 @@ main()
 
 - **Q**: I am not satisfied with the tissue vs background segmentation. What can I do?
    - **A**: Trident uses GeoJSON to store and load segmentations. This format is natively supported by [QuPath](https://qupath.github.io/). You can load the Trident segmentation into QuPath, modify it using QuPath's annotation tools, and save the updated segmentation back to GeoJSON.
-   - **A**: You can try rerunning the segmentation step at a higher magnification (which may be slower, but more accurate).
-   - **A**: You can finetune the Trident segmentation model on a few annotated examples to improve performance for your specific use case.
+   - **A**: You can try another segmentation model by specifying `segmenter --grandqc`.
 
 - **Q**: I want to process a custom list of WSIs. Can I do it? Also, most of my WSIs don't have the micron per pixel (mpp) stored. Can I pass it?
    - **A**: Yes using the `--custom_list_of_wsis` argument. Provide a list of WSI names in a CSV (with slide extension, `wsi`). Optionally, provide the mpp (field `mpp`)

--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ python run_single_slide.py --slide_path wsis/xxxx.svs --job_dir ./trident_proces
 **Step 1: Tissue Segmentation:** Segments tissue vs. background from a list of WSIs
  - **Command**:
    ```bash
-   python run_batch_of_slides.py --task seg --wsi_dir ./wsis --job_dir ./trident_processed --gpu 0
+   python run_batch_of_slides.py --task seg --wsi_dir ./wsis --job_dir ./trident_processed --gpu 0 --segmenter hest
    ```
    - `--task seg`: Specifies that you want to do tissue segmentation.
    - `--wsi_dir ./wsis`: Path to the directory containing WSIs.
    - `--job_dir ./trident_processed`: Output directory for processed results.
    - `--gpu 0`: Uses GPU with index 0 for computation.
+   - `--segmenter`: Segmentation model. Defaults to `hest`. Switch to `grandqc` for fast H&E segmentation.
  - **Outputs**:
    - WSI thumbnails are saved in `./trident_processed/thumbnails`.
    - WSI thumbnails annotated with tissue contours are saved in `./trident_processed/contours`.

--- a/run_batch_of_slides.py
+++ b/run_batch_of_slides.py
@@ -38,8 +38,9 @@ def parse_arguments():
     parser.add_argument('--skip_errors', action='store_true', default=False, 
                         help='Skip errored slides and continue processing')
     # Segmentation arguments 
-    parser.add_argument('--fast_seg', action='store_true', default=False, 
-                        help='Run tissue segmentation at 5x (faster) or 10x (default)')
+    parser.add_argument('--segmenter', type=str, default='hest', 
+                        choices=['hest', 'grandqc',], 
+                        help='Type of tissue vs background segmenter. Options are HEST or GrandQC.')
     parser.add_argument('--remove_holes', action='store_true', default=False, 
                         help='Do you want to remove holes?')
     # Patching arguments
@@ -95,10 +96,10 @@ def run_task(processor, args):
         # Minimal example for tissue segmentation:
         # python run_batch_of_slides.py --task seg --wsi_dir wsis --job_dir trident_processed --gpu 0
         from trident.segmentation_models.load import segmentation_model_factory
-        segmentation_model = segmentation_model_factory('hest', device=f'cuda:{args.gpu}')
+        segmentation_model = segmentation_model_factory(args.segmenter, device=f'cuda:{args.gpu}')
         processor.run_segmentation_job(
             segmentation_model,
-            seg_mag=5 if args.fast_seg else 10,
+            seg_mag=segmentation_model.target_mag,
             holes_are_tissue= not args.remove_holes,
         )
     elif args.task == 'coords':

--- a/run_batch_of_slides.py
+++ b/run_batch_of_slides.py
@@ -41,6 +41,8 @@ def parse_arguments():
     parser.add_argument('--segmenter', type=str, default='hest', 
                         choices=['hest', 'grandqc',], 
                         help='Type of tissue vs background segmenter. Options are HEST or GrandQC.')
+    parser.add_argument('--seg_conf_thresh', type=float, default=0.5, 
+                    help='Confidence threshold to apply to binarize segmentation predictions. Lower this threhsold to retain more tissue. Defaults to 0.5. Try 0.4 as 2nd option.')
     parser.add_argument('--remove_holes', action='store_true', default=False, 
                         help='Do you want to remove holes?')
     # Patching arguments
@@ -96,7 +98,11 @@ def run_task(processor, args):
         # Minimal example for tissue segmentation:
         # python run_batch_of_slides.py --task seg --wsi_dir wsis --job_dir trident_processed --gpu 0
         from trident.segmentation_models.load import segmentation_model_factory
-        segmentation_model = segmentation_model_factory(args.segmenter, device=f'cuda:{args.gpu}')
+        segmentation_model = segmentation_model_factory(
+            args.segmenter,
+            confidence_thresh=args.seg_conf_thresh,
+            device=f'cuda:{args.gpu}'
+        )
         processor.run_segmentation_job(
             segmentation_model,
             seg_mag=segmentation_model.target_mag,

--- a/tests/test_segmentation_models.py
+++ b/tests/test_segmentation_models.py
@@ -23,7 +23,7 @@ class TestSegmentationModels(unittest.TestCase):
     def _test_forward(self, encoder_name):
         print("\033[95m" + f"Testing {encoder_name} forward pass" + "\033[0m")
         device = 'cuda' if torch.cuda.is_available() else 'cpu'
-        encoder = segmentation_model_factory(encoder_name, device)
+        encoder = segmentation_model_factory(encoder_name, device=device)
 
         self.dummy_image = np.random.randint(0, 256, (encoder.input_size, encoder.input_size, 3), dtype=np.uint8)
         self.dummy_image = Image.fromarray(self.dummy_image)

--- a/trident/segmentation_models/__init__.py
+++ b/trident/segmentation_models/__init__.py
@@ -1,4 +1,4 @@
 # in submodule
-from trident.segmentation_models.load import segmentation_model_factory, HESTSegmenter
+from trident.segmentation_models.load import segmentation_model_factory, HESTSegmenter,GrandQCSegmenter
 
-__all__ = [segmentation_model_factory, HESTSegmenter]
+__all__ = [segmentation_model_factory, HESTSegmenter, GrandQCSegmenter]

--- a/trident/segmentation_models/load.py
+++ b/trident/segmentation_models/load.py
@@ -48,7 +48,14 @@ class HESTSegmenter(SegmentationModel):
                 from huggingface_hub import snapshot_download
             except:
                 raise Exception("Please install huggingface_hub (`pip install huggingface_hub`) to use this model")
-            snapshot_download(repo_id="MahmoodLab/hest-tissue-seg", repo_type='model', local_dir=checkpoint_dir, cache_dir=checkpoint_dir)
+            
+            snapshot_download(
+                repo_id="MahmoodLab/hest-tissue-seg",
+                repo_type='model',
+                local_dir=checkpoint_dir,
+                cache_dir=checkpoint_dir,
+                allow_patterns=["*.ckpt"]
+            )
 
         checkpoint = torch.load(os.path.join(checkpoint_dir, 'deeplabv3_seg_v4.ckpt'), map_location=torch.device('cpu'), weights_only=False)
             
@@ -62,6 +69,8 @@ class HESTSegmenter(SegmentationModel):
         model.to(device)
         self.device = device
         self.input_size = 512
+        self.precision = torch.float16
+        self.target_mag = 10
 
         eval_transforms = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.485, 0.456, 0.406), (0.229, 0.224, 0.225))])
 
@@ -75,7 +84,82 @@ class HESTSegmenter(SegmentationModel):
         predictions = (softmax_output[:, 1, :, :] > self.confidence_thresh).to(torch.uint8)  # Shape: [bs, 512, 512]
         return predictions
         
- 
+class JpegCompressionTransform:
+    def __init__(self, quality=80):
+        self.quality = quality
+
+    def __call__(self, image):
+        import cv2
+        import numpy as np
+        from PIL import Image
+        # Convert PIL Image to NumPy array
+        image = np.array(image)
+
+        # Apply JPEG compression
+        encode_param = [int(cv2.IMWRITE_JPEG_QUALITY), self.quality]
+        _, image = cv2.imencode('.jpg', image, encode_param)
+        image = cv2.imdecode(image, cv2.IMREAD_COLOR)
+
+        # Convert back to PIL Image
+        return Image.fromarray(image)
+
+
+
+class GrandQCSegmenter(SegmentationModel):
+
+    def _build(self, checkpoint_dir, device):
+        import segmentation_models_pytorch as smp
+
+        self.device = device
+        self.input_size = 512
+        self.precision = torch.float32
+        self.target_mag = 1
+
+        MODEL_TD_NAME = 'Tissue_Detection_MPP10.pth'
+        ENCODER_MODEL_TD = 'timm-efficientnet-b0'
+        ENCODER_MODEL_TD_WEIGHTS = 'imagenet'
+
+        # eval_transforms = smp.encoders.get_preprocessing_fn(ENCODER_MODEL_TD, ENCODER_MODEL_TD_WEIGHTS)
+        eval_transforms = transforms.Compose([
+            JpegCompressionTransform(quality=80),
+            transforms.ToTensor(),  # Converts to [0,1] range and moves channels to [C, H, W]
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+        ])
+
+        model = smp.UnetPlusPlus(
+            encoder_name=ENCODER_MODEL_TD,
+            encoder_weights=ENCODER_MODEL_TD_WEIGHTS,
+            classes=2,
+            activation=None,
+        )
+
+        if not os.path.isfile(os.path.join(checkpoint_dir, MODEL_TD_NAME)):
+            try:
+                from huggingface_hub import snapshot_download
+            except:
+                raise Exception("Please install huggingface_hub (`pip install huggingface_hub`) to use this model")
+            snapshot_download(
+                repo_id="MahmoodLab/hest-tissue-seg",
+                repo_type='model',
+                local_dir=checkpoint_dir,
+                cache_dir=checkpoint_dir,
+                allow_patterns=["*.pth"],
+            )
+
+        model.load_state_dict(torch.load(os.path.join(checkpoint_dir, MODEL_TD_NAME), map_location='cpu'))
+        model.to(device)
+        model.eval()
+
+        return model, eval_transforms
+
+    def forward(self, batch):
+        '''
+        Custom forward pass.
+        '''
+        logits = self.model.predict(batch)        
+        predictions =  1 - torch.argmax(logits, dim=1).to(torch.uint8)
+        return predictions
+
 
 def segmentation_model_factory(model_name, device, freeze=True):
     '''
@@ -83,5 +167,7 @@ def segmentation_model_factory(model_name, device, freeze=True):
     '''
     if model_name == 'hest':
         return HESTSegmenter(freeze, checkpoint_dir = os.path.join(current_dir, 'hest-tissue-seg/'), device = device)
+    elif model_name == 'grandqc':
+        return GrandQCSegmenter(freeze, checkpoint_dir = os.path.join(current_dir, 'grandqc/'), device = device)
     else:
         raise ValueError(f"Model type {model_name} not supported")

--- a/trident/segmentation_models/load.py
+++ b/trident/segmentation_models/load.py
@@ -168,7 +168,7 @@ class GrandQCSegmenter(SegmentationModel):
         return predictions
 
 
-def segmentation_model_factory(model_name, confidence_thresh, device, freeze=True):
+def segmentation_model_factory(model_name, confidence_thresh=0.5, device='cuda', freeze=True):
     '''
     Build a slide encoder based on model name.
     '''

--- a/trident/segmentation_models/load.py
+++ b/trident/segmentation_models/load.py
@@ -108,6 +108,9 @@ class JpegCompressionTransform:
 class GrandQCSegmenter(SegmentationModel):
 
     def _build(self, checkpoint_dir, device):
+        """
+        Credit to https://www.nature.com/articles/s41467-024-54769-y
+        """
         import segmentation_models_pytorch as smp
 
         self.device = device


### PR DESCRIPTION
- Support for one additional tissue vs segmentation model based on GrandQC (Nat. Comm, 2024, https://www.nature.com/articles/s41467-024-54769-y). Much faster. Very good for H&E. Very bad for IHC and special stains. Can be used with `--segmenter grandqc`
- Expose tissue confidence threshold. Default to 0.5 thresh. Reducing it to 0.4 in challenging cases seem to help. Tested in PDL-1 on 100 WSIs. 