### PR TITLE
fix unexpected keyword arg in _build

### DIFF
--- a/trident/slide_encoder_models/load.py
+++ b/trident/slide_encoder_models/load.py
@@ -27,7 +27,7 @@ def encoder_factory(model_name, pretrained=True, freeze=True, **kwargs):
 
         if model_name.startswith('mean-'):
             enc = MeanSlideEncoder
-            return enc(model_name = model_name, pretrained = pretrained, freeze = freeze, **kwargs)
+            return enc(model_name = model_name)
         elif 'threads' in model_name:
             # raise ValueError(f"threads is not public. Coming soon!")
             enc = ThreadsSlideEncoder

--- a/trident/slide_encoder_models/load.py
+++ b/trident/slide_encoder_models/load.py
@@ -27,6 +27,7 @@ def encoder_factory(model_name, pretrained=True, freeze=True, **kwargs):
 
         if model_name.startswith('mean-'):
             enc = MeanSlideEncoder
+            return enc(model_name = model_name, pretrained = pretrained, freeze = freeze, **kwargs)
         elif 'threads' in model_name:
             # raise ValueError(f"threads is not public. Coming soon!")
             enc = ThreadsSlideEncoder
@@ -45,7 +46,7 @@ def encoder_factory(model_name, pretrained=True, freeze=True, **kwargs):
         else:
             raise ValueError(f"Model type {model_name} not supported")
         
-        return enc(model_name = model_name, pretrained = pretrained, freeze = freeze, **kwargs)
+        return enc(pretrained = pretrained, freeze = freeze, **kwargs)
     
 # Map from slide encoder to required patch encoder
 # Used in Processor.py to load the correct patch encoder for a given slide encoder


### PR DESCRIPTION
fixes issue #33 

As only MeanSlideEncoder seems to need model_name as an input argument, just treats that as special case and removes it from the rest