### PR TITLE
batch_size on slide-encoder to save memory

### DIFF
--- a/run_batch_of_slides.py
+++ b/run_batch_of_slides.py
@@ -143,6 +143,7 @@ def run_task(processor, args):
                 coords_dir=args.coords_dir or f'{args.mag}x_{args.patch_size}px_{args.overlap}px_overlap',
                 device=f'cuda:{args.gpu}',
                 saveas='h5',
+                batch_limit=args.batch_size
             )
     else:
         raise ValueError(f'Invalid task: {args.task}')


### PR DESCRIPTION
This seemed to get things working for us on smaller GPUs. Studying the code, it looks like batch_limit wont impact the slide encoder itself, but just the patch encoder. Is this correct?