### PR TITLE
support arbitrary user specified inference methods for patch feature generation

### DIFF
--- a/trident/InferenceStrategy.py
+++ b/trident/InferenceStrategy.py
@@ -1,0 +1,63 @@
+from typing import Protocol
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+from trident.patch_encoder_models.load import BasePatchEncoder, CustomInferenceEncoder
+
+
+class InferenceStrategy(Protocol):
+    """
+    An interface that supports arbitrary strategies for inference of
+    image patch embedding models.
+    """
+
+    def forward(
+        self,
+        dataloader: DataLoader,
+        patch_encoder: BasePatchEncoder | CustomInferenceEncoder,
+        device: torch.device,
+        precision: torch.dtype,
+    ) -> np.ndarray: ...
+
+
+class DefaultInferenceStrategy(InferenceStrategy):
+    """
+    This is the default inference strategy for embedding image patches.
+    It sequentially processes one batch at a time on the specified device/GPU.
+    Automatic mixed precision is enabled if `precision` != torch.float32.
+
+    Args:
+        dataloader (DataLoader):
+            A dataloader that generates image patches.
+        patch_encoder (BasePatchEncoder | CustomInferenceEncoder):
+            The image patch embedding model.
+        device (torch.device):
+            Device to run feature extraction on (e.g., 'cuda:0').
+        precision (torch.dtype):
+            Precision of embedding model weights (e.g. torch.float32).
+
+    Returns:
+        embeddings (np.ndarray): The embeddings for the batch of image patches
+    """
+
+    def forward(
+        self,
+        dataloader: DataLoader,
+        patch_encoder: BasePatchEncoder | CustomInferenceEncoder,
+        device: torch.device,
+        precision: torch.dtype,
+    ) -> np.ndarray:
+        features = []
+        for imgs, _ in dataloader:
+            imgs = imgs.to(device)
+            with torch.autocast(
+                device_type="cuda",
+                dtype=precision,
+                enabled=(precision != torch.float32),
+            ):
+                batch_features = patch_encoder(imgs)
+            features.append(batch_features.cpu().numpy())
+        features = np.concatenate(features, axis=0)
+        return features

--- a/trident/Processor.py
+++ b/trident/Processor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import os
 import sys
+import torch
 from tqdm import tqdm
 import shutil
 from typing import Optional, List, Dict, Any
@@ -8,6 +9,8 @@ from inspect import signature
 import geopandas as gpd
 
 from trident.IO import create_lock, remove_lock, is_locked, update_log
+from trident.patch_encoder_models.load import BasePatchEncoder, CustomInferenceEncoder
+from trident.InferenceStrategy import InferenceStrategy, DefaultInferenceStrategy
 from trident.wsi_objects.WSI import OpenSlideWSI
 
 
@@ -137,7 +140,7 @@ class Processor:
             print(f'Using local cache at {wsi_cache}, which currently contains {len(os.listdir(wsi_cache))} files.')
 
         # Lazy-init WSI objects
-        self.wsis = []
+        self.wsis: List[OpenSlideWSI]  = []
         for wsi_idx, wsi in enumerate(valid_slides):
             wsi_path = os.path.join(self.wsi_cache, wsi) if self.wsi_cache is not None else os.path.join(self.wsi_source, wsi)
             
@@ -451,11 +454,13 @@ class Processor:
     def run_patch_feature_extraction_job(
         self, 
         coords_dir: str, 
-        patch_encoder: torch.nn.Module, 
+        patch_encoder: BasePatchEncoder | CustomInferenceEncoder, 
         device: str, 
         saveas: str = 'h5', 
         batch_limit: int = 512, 
-        saveto: str | None = None
+        saveto: str | None = None,
+        inference_strategy: InferenceStrategy = DefaultInferenceStrategy(),
+        pin_memory: bool = True
     ) -> str:
         """
         The `run_feature_extraction_job` function computes features from the patches generated during the 
@@ -465,8 +470,8 @@ class Processor:
         Parameters:
             coords_dir (str): 
                 Path to the directory containing patch coordinates, which are used to locate patches for feature extraction.
-            patch_encoder (torch.nn.Module): 
-                A pre-trained PyTorch model used to compute features from the extracted patches.
+            patch_encoder (BasePatchEncoder | CustomInferenceEncoder):
+                A pre-trained model used to compute features from the extracted patches.
             device (str): 
                 The computation device to use (e.g., 'cuda:0' for GPU or 'cpu' for CPU).
             saveas (str, optional): 
@@ -476,6 +481,14 @@ class Processor:
             saveto (str, optional): 
                 Directory where the extracted features will be saved. If not provided, a directory name will 
                 be generated automatically. Defaults to None.
+            inference_strategy (InferenceStrategy, optional):
+                Allows you to provide arbitrary logic for running inference. Useful
+                for non-Pytorch models, or advanced needs such as model and data parallelism.
+                The default implementation assumes a Pytorch model running on a single
+                GPU, and enables automatic mixed precision when dtype != torch.float32.
+            pin_memory (bool, optional):
+                If True, the data loader will copy Tensors into device/CUDA pinned memory
+                before returning them. Defaults to True.
 
         Returns:
             str: The absolute path to where the features are saved.
@@ -505,15 +518,18 @@ class Processor:
             ignore = ['patch_encoder', 'loop', 'valid_slides', 'wsis']
         )
 
-        patch_encoder.eval()
-        patch_encoder.to(device)
+        # check if patch_encoder is a Pytorch model
+        if isinstance(patch_encoder, torch.nn.Module):
+            patch_encoder.eval()
+            patch_encoder.to(device)
+
         log_fp = os.path.join(self.job_dir, coords_dir, f'_logs_feats_{patch_encoder.enc_name}.txt')
         self.loop = tqdm(self.wsis, desc=f'Extracting patch features from coords in {coords_dir}', total = len(self.wsis))
         for wsi in self.loop:    
             wsi_feats_fp = os.path.join(self.job_dir, saveto, f'{wsi.name}.{saveas}')
             # Check if features already exist
             if os.path.exists(wsi_feats_fp) and not is_locked(wsi_feats_fp):
-                self.loop.set_postfix_str(f'Features already extracted for {wsi}. Skipping...')
+                self.loop.set_postfix_str(f'Features already extracted for {wsi.name}. Skipping...')
                 update_log(log_fp, f'{wsi.name}{wsi.ext}', 'Features extracted.')
                 self.cleanup(f'{wsi.name}{wsi.ext}')
                 continue
@@ -549,7 +565,9 @@ class Processor:
                     save_features=os.path.join(self.job_dir, saveto),
                     device=device,
                     saveas=saveas,
-                    batch_limit=batch_limit
+                    batch_limit=batch_limit,
+                    inference_strategy=inference_strategy,
+                    pin_memory=pin_memory
                 )
 
                 remove_lock(wsi_feats_fp)

--- a/trident/Processor.py
+++ b/trident/Processor.py
@@ -518,10 +518,15 @@ class Processor:
             ignore = ['patch_encoder', 'loop', 'valid_slides', 'wsis']
         )
 
-        # check if patch_encoder is a Pytorch model
+        # If patch_encoder is a Pytorch model, or a CustomInferenceEncoder that wraps
+        # a PyTorch model, we automatically set eval mode and move weights to specified device.
+        # In all other cases, the user must ensure data and weights reside on the same device.
         if isinstance(patch_encoder, torch.nn.Module):
             patch_encoder.eval()
             patch_encoder.to(device)
+        elif isinstance(patch_encoder.model, torch.nn.Module):
+            patch_encoder.model.eval()
+            patch_encoder.model.to(device)
 
         log_fp = os.path.join(self.job_dir, coords_dir, f'_logs_feats_{patch_encoder.enc_name}.txt')
         self.loop = tqdm(self.wsis, desc=f'Extracting patch features from coords in {coords_dir}', total = len(self.wsis))

--- a/trident/patch_encoder_models/load.py
+++ b/trident/patch_encoder_models/load.py
@@ -1,5 +1,7 @@
 import traceback
 from abc import abstractmethod
+from typing import Callable
+import numpy as np
 import torch
 import os 
 
@@ -91,16 +93,21 @@ class BasePatchEncoder(torch.nn.Module):
         pass
 
 
-class CustomInferenceEncoder(BasePatchEncoder):
-    def __init__(self, enc_name, model, transforms, precision):
-        super().__init__()
+class CustomInferenceEncoder:
+    def __init__(
+        self,
+        enc_name: str,
+        model: Callable[..., np.ndarray],
+        transforms: Callable,
+        precision: torch.dtype,
+    ):
         self.enc_name = enc_name
         self.model = model
         self.eval_transforms = transforms
         self.precision = precision
-        
-    def _build(self):
-        return None, None, None
+
+    def __call__(self, *args, **kwargs):
+        return self.model(*args, **kwargs)
 
 
 class MuskInferenceEncoder(BasePatchEncoder):


### PR DESCRIPTION
## Summary

These backwards compatible changes allow users to provide custom inference behavior for generating patch features/embeddings from a WSI. This maintains first-class support for PyTorch models, while enabling advanced use cases such as non-PyTorch models or distributed inference through model/data parallelism.

## Background

Currently TRIDENT offers a convenient solution for utilizing a custom foundation model to generate patch features/embeddings, via the `CustomInferenceEncoder` class (see Tutorial 2). However, the code in `OpenSlideWSI.extract_patch_features(...)` and elsewhere assumes two key details: (1) the model is PyTorch based, (2) a single device/gpu is used for inference.

## Motivation

### Non-PyTorch Models

Example use cases include: JAX models, HTTP APIs, custom GPU kernels, optimized models/runtimes à la TensorRT etc.

### Distributed & Parallel Inference

To support large models and datasets, the ability to use arbitrary distributed and parallel techniques would be helpful. 

## Implementation

I factored out the core inference loop in `OpenSlideWSI.extract_patch_features(...)` and created a formalized interface that allows users to provide arbitrary implementations via the new `inference_strategy` argument. Additionally the `pin_memory` argument is now available so users can disable the default behavior which loads input tensors to GPU. The changes in this PR are completely backwards compatible and fully supported by static type checkers.

### Example Usage

Here is a simplified example to demonstrate use of the new features:

```python
import numpy as np
import torch
import torchvision.transforms as transforms
from torch.utils.data import DataLoader
from trident.InferenceStrategy import InferenceStrategy
from trident.patch_encoder_models import CustomInferenceEncoder
from trident.patch_encoder_models.load import BasePatchEncoder
from trident.Processor import Processor
from trident.segmentation_models import segmentation_model_factory

# custom non-PyTorch model, just a plain function
def my_custom_model(x: torch.Tensor):
    return torch.rand(x.shape[0], 128)

# custom inference loop over WSI patches
class MyCustomInferenceStrategy(InferenceStrategy):
    def forward(
        self,
        dataloader: DataLoader,
        patch_encoder: BasePatchEncoder | CustomInferenceEncoder,
        device: torch.device,
        precision: torch.dtype,
    ) -> np.ndarray:
        return np.concatenate([patch_encoder(imgs) for imgs, _ in dataloader], axis=0)


# Create processor
processor = Processor(
    wsi_source="input",  # Directory containing WSI files
    job_dir="output,  # Directory to store outputs
)

# Run tissue vs background segmentation
segmentation_model = segmentation_model_factory("hest", device="cuda")
processor.run_segmentation_job(
    segmentation_model,
)

# Run tissue coordinate extraction (256x256 at 20x)
processor.run_patching_job(target_magnification=20, patch_size=256, overlap=0)

# Run feature extraction using custom model and inference logic
processor.run_patch_feature_extraction_job(
    coords_dir=f"20x_256px_0px_overlap",
    patch_encoder=CustomInferenceEncoder(
        enc_name="my_custom_model",
        model=my_custom_model, # our custom non-PyTorch model
        transforms=transforms.ToTensor(),
        precision=torch.float32,
    ),
    inference_strategy=MyCustomInferenceStrategy(), # NEW: custom inference implementation
    device="cpu",
    saveas="h5",
    batch_limit=1024,
    pin_memory=False # NEW: ability to prevent loading input tensors to GPU
)
```

## Tests

Feel free to provide suggestions on test cases to add.

## Documentation

If you find these changes agreeable please let me know and I'll add further polish by updating the documentation and tutorial(s) to include example usage.

## Acknowledgements

Thanks for making what appears to be a great successor to the well known CLAM project!