### PR TITLE
GJA: Custom inference strategy

### DIFF
--- a/trident/InferenceStrategy.py
+++ b/trident/InferenceStrategy.py
@@ -1,0 +1,63 @@
+from typing import Protocol
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+from trident.patch_encoder_models.load import BasePatchEncoder, CustomInferenceEncoder
+
+
+class InferenceStrategy(Protocol):
+    """
+    An interface that supports arbitrary strategies for inference of
+    image patch embedding models.
+    """
+
+    def forward(
+        self,
+        dataloader: DataLoader,
+        patch_encoder: BasePatchEncoder | CustomInferenceEncoder,
+        device: torch.device,
+        precision: torch.dtype,
+    ) -> np.ndarray: ...
+
+
+class DefaultInferenceStrategy(InferenceStrategy):
+    """
+    This is the default inference strategy for embedding image patches.
+    It sequentially processes one batch at a time on the specified device/GPU.
+    Automatic mixed precision is enabled if `precision` != torch.float32.
+
+    Args:
+        dataloader (DataLoader):
+            A dataloader that generates image patches.
+        patch_encoder (BasePatchEncoder | CustomInferenceEncoder):
+            The image patch embedding model.
+        device (torch.device):
+            Device to run feature extraction on (e.g., 'cuda:0').
+        precision (torch.dtype):
+            Precision of embedding model weights (e.g. torch.float32).
+
+    Returns:
+        embeddings (np.ndarray): The embeddings for the batch of image patches
+    """
+
+    def forward(
+        self,
+        dataloader: DataLoader,
+        patch_encoder: BasePatchEncoder | CustomInferenceEncoder,
+        device: torch.device,
+        precision: torch.dtype,
+    ) -> np.ndarray:
+        features = []
+        for imgs, _ in dataloader:
+            imgs = imgs.to(device)
+            with torch.autocast(
+                device_type="cuda",
+                dtype=precision,
+                enabled=(precision != torch.float32),
+            ):
+                batch_features = patch_encoder(imgs)
+            features.append(batch_features.cpu().numpy())
+        features = np.concatenate(features, axis=0)
+        return features

--- a/trident/Processor.py
+++ b/trident/Processor.py
@@ -532,7 +532,9 @@ class Processor:
             ignore = ['patch_encoder', 'loop', 'valid_slides', 'wsis']
         )
 
-        # check if patch_encoder is a Pytorch model
+        # If patch_encoder is a Pytorch model, or a CustomInferenceEncoder that wraps
+        # a PyTorch model, we automatically set eval mode and move weights to specified device.
+        # In all other cases, the user must ensure data and weights reside on the same device.
         if isinstance(patch_encoder, torch.nn.Module):
             patch_encoder.eval()
             patch_encoder.to(device)

--- a/trident/patch_encoder_models/load.py
+++ b/trident/patch_encoder_models/load.py
@@ -1,6 +1,7 @@
 import traceback
 from abc import abstractmethod
-from typing import Optional
+from typing import Optional, Callable
+import numpy as np
 import torch
 import os 
 
@@ -171,8 +172,14 @@ class BasePatchEncoder(torch.nn.Module):
         pass
 
 
-class CustomInferenceEncoder(BasePatchEncoder):
-    def __init__(self, enc_name, model, transforms, precision):
+class CustomInferenceEncoder:
+    def __init__(
+        self,
+        enc_name: str,
+        model: Callable[..., np.ndarray],
+        transforms: Callable,
+        precision: torch.dtype,
+    ):
         """
         Initialize a CustomInferenceEncoder from user-defined components.
 
@@ -182,8 +189,8 @@ class CustomInferenceEncoder(BasePatchEncoder):
         Args:
             enc_name (str): 
                 A unique name or identifier for the encoder (used for registry or logging).
-            model (torch.nn.Module): 
-                A PyTorch model instance to use for inference.
+            model Callable[..., np.ndarray]: 
+                A model instance to use for inference.
             transforms (Callable): 
                 A callable (e.g., torchvision or timm transform) to preprocess input images for evaluation.
             precision (torch.dtype): 
@@ -194,9 +201,9 @@ class CustomInferenceEncoder(BasePatchEncoder):
         self.model = model
         self.eval_transforms = transforms
         self.precision = precision
-        
-    def _build(self):
-        return None, None, None
+
+    def __call__(self, *args, **kwargs):
+        return self.model(*args, **kwargs)
 
 
 class MuskInferenceEncoder(BasePatchEncoder):

--- a/trident/wsi_objects/WSI.py
+++ b/trident/wsi_objects/WSI.py
@@ -6,8 +6,12 @@ import warnings
 import torch 
 from typing import List, Tuple, Optional, Literal
 from torch.utils.data import DataLoader
+import geopandas as gpd
+import cv2
 
-from trident.wsi_objects.WSIPatcher import *
+from trident.patch_encoder_models.load import BasePatchEncoder, CustomInferenceEncoder
+from trident.InferenceStrategy import InferenceStrategy, DefaultInferenceStrategy
+from trident.wsi_objects.WSIPatcher import OpenSlideWSIPatcher
 from trident.wsi_objects.WSIPatcherDataset import WSIPatcherDataset
 from trident.IO import (
     save_h5, read_coords, read_coords_legacy,
@@ -611,12 +615,14 @@ class WSI:
     @torch.inference_mode()
     def extract_patch_features(
         self,
-        patch_encoder: torch.nn.Module,
+        patch_encoder: BasePatchEncoder | CustomInferenceEncoder,
         coords_path: str,
         save_features: str,
         device: str = 'cuda:0',
         saveas: str = 'h5',
-        batch_limit: int = 512
+        batch_limit: int = 512,
+        inference_strategy: InferenceStrategy = DefaultInferenceStrategy(),
+        pin_memory: bool = True
     ) -> str:
         """
         The `extract_patch_features` function of the class `WSI` extracts feature embeddings 
@@ -625,7 +631,7 @@ class WSI:
 
         Args:
         -----
-        patch_encoder : torch.nn.Module
+        patch_encoder : BasePatchEncoder | CustomInferenceEncoder
             The model used for feature extraction.
         coords_path : str
             Path to the file containing patch coordinates.
@@ -637,6 +643,14 @@ class WSI:
             Format to save the features ('h5' or 'pt'). Defaults to 'h5'.
         batch_limit : int, optional
             Maximum batch size for feature extraction. Defaults to 512.
+        inference_strategy (InferenceStrategy, optional):
+            Allows you to provide arbitrary logic for running inference. Useful
+            for non-Pytorch models, or advanced needs such as model and data parallelism.
+            The default implementation assumes a Pytorch model running on a single
+            GPU, and enables automatic mixed precision when dtype != torch.float32.
+        pin_memory (bool, optional):
+            If True, the data loader will copy Tensors into device/CUDA pinned memory
+            before returning them. Defaults to True.
 
         Returns:
         --------
@@ -645,7 +659,7 @@ class WSI:
 
         Example:
         --------
-        >>> features_path = wsi.extract_features(patch_encoder, "output_coords/sample_name_patches.h5", "output_features")
+        >>> features_path = wsi.extract_patch_features(patch_encoder, "output_coords/sample_name_patches.h5", "output_features")
         >>> print(features_path)
         output_features/sample_name.h5
         """
@@ -679,17 +693,7 @@ class WSI:
         )
         dataset = WSIPatcherDataset(patcher, patch_transforms)
         dataloader = DataLoader(dataset, batch_size=batch_limit, num_workers=get_num_workers(batch_limit, max_workers=self.max_workers), pin_memory=True)
-        # dataloader = DataLoader(dataset, batch_size=batch_limit, num_workers=0, pin_memory=True)
-
-        features = []
-        for imgs, _ in dataloader:
-            imgs = imgs.to(device)
-            with torch.autocast(device_type='cuda', dtype=precision, enabled=(precision != torch.float32)):
-                batch_features = patch_encoder(imgs)  
-            features.append(batch_features.cpu().numpy())
-
-        # Concatenate features
-        features = np.concatenate(features, axis=0)
+        features = inference_strategy.forward(dataloader, patch_encoder, device, precision)
 
         # Save the features to disk
         os.makedirs(save_features, exist_ok=True)


### PR DESCRIPTION
Rebase from @jakebytes

## Summary

These backwards compatible changes allow users to provide custom inference behavior for generating patch features/embeddings from a WSI. This maintains first-class support for PyTorch models, while enabling advanced use cases such as non-PyTorch models or distributed inference through model/data parallelism.

## Background

Currently TRIDENT offers a convenient solution for utilizing a custom foundation model to generate patch features/embeddings, via the `CustomInferenceEncoder` class (see Tutorial 2). However, the code in `OpenSlideWSI.extract_patch_features(...)` and elsewhere assumes two key details: (1) the model is PyTorch based, (2) a single device/gpu is used for inference.

## Motivation

### Non-PyTorch Models

Example use cases include: JAX models, HTTP APIs, custom GPU kernels, optimized models/runtimes à la TensorRT etc.

### Distributed & Parallel Inference

To support large models and datasets, the ability to use arbitrary distributed and parallel techniques would be helpful. 

## Implementation

I factored out the core inference loop in `OpenSlideWSI.extract_patch_features(...)` and created a formalized interface that allows users to provide arbitrary implementations via the new `inference_strategy` argument. Additionally the `pin_memory` argument is now available so users can disable the default behavior which loads input tensors to GPU. The changes in this PR are completely backwards compatible and fully supported by static type checkers.

### Example Usage

Here is a simplified example to demonstrate use of the new features:

```python
import numpy as np
import torch
import torchvision.transforms as transforms
from torch.utils.data import DataLoader
from trident.InferenceStrategy import InferenceStrategy
from trident.patch_encoder_models import CustomInferenceEncoder
from trident.patch_encoder_models.load import BasePatchEncoder
from trident.Processor import Processor
from trident.segmentation_models import segmentation_model_factory

# custom non-PyTorch model, just a plain function
def my_custom_model(x: torch.Tensor):
    return torch.rand(x.shape[0], 128)

# custom inference loop over WSI patches
class MyCustomInferenceStrategy(InferenceStrategy):
    def forward(
        self,
        dataloader: DataLoader,
        patch_encoder: BasePatchEncoder | CustomInferenceEncoder,
        device: torch.device,
        precision: torch.dtype,
    ) -> np.ndarray:
        return np.concatenate([patch_encoder(imgs) for imgs, _ in dataloader], axis=0)


# Create processor
processor = Processor(
    wsi_source="input",  # Directory containing WSI files
    job_dir="output,  # Directory to store outputs
)

# Run tissue vs background segmentation
segmentation_model = segmentation_model_factory("hest", device="cuda")
processor.run_segmentation_job(
    segmentation_model,
)

# Run tissue coordinate extraction (256x256 at 20x)
processor.run_patching_job(target_magnification=20, patch_size=256, overlap=0)

# Run feature extraction using custom model and inference logic
processor.run_patch_feature_extraction_job(
    coords_dir=f"20x_256px_0px_overlap",
    patch_encoder=CustomInferenceEncoder(
        enc_name="my_custom_model",
        model=my_custom_model, # our custom non-PyTorch model
        transforms=transforms.ToTensor(),
        precision=torch.float32,
    ),
    inference_strategy=MyCustomInferenceStrategy(), # NEW: custom inference implementation
    device="cpu",
    saveas="h5",
    batch_limit=1024,
    pin_memory=False # NEW: ability to prevent loading input tensors to GPU
)
```

## Tests

Feel free to provide suggestions on test cases to add.

## Documentation

If you find these changes agreeable please let me know and I'll add further polish by updating the documentation and tutorial(s) to include example usage.

## Acknowledgements

Thanks for making what appears to be a great successor to the well known CLAM project!