### PR TITLE
add support for Midnight-12k patch encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Trident supports 21 patch encoders, loaded via a patch [`encoder_factory`](https
 - **H-Optimus-0**: [bioptimus/H-optimus-0](https://huggingface.co/bioptimus/H-optimus-0)  (`--patch_encoder hoptimus0 --patch_size 224 --mag 20`)
 - **H-Optimus-1**: [bioptimus/H-optimus-1](https://huggingface.co/bioptimus/H-optimus-1)  (`--patch_encoder hoptimus1 --patch_size 224 --mag 20`)
 - **MUSK**: [xiangjx/musk](https://huggingface.co/xiangjx/musk)  (`--patch_encoder musk --patch_size 384 --mag 20`)
+- **Midnight-12k**: [kaiko-ai/midnight](https://huggingface.co/kaiko-ai/midnight)  (`--patch_encoder midnight12k --patch_size 224 --mag 20`)
 - **Kaiko**: Hosted on TorchHub  (`--patch_encoder {kaiko-vits8, kaiko-vits16, kaiko-vitb8, kaiko-vitb16, kaiko-vitl14} --patch_size 256 --mag 20`)
 - **Lunit**: [1aurent/vit_small_patch8_224.lunit_dino](https://huggingface.co/1aurent/vit_small_patch8_224.lunit_dino)  (`--patch_encoder lunit-vits8 --patch_size 224 --mag 20`)
 - **Hibou**: [histai/hibou-L](https://huggingface.co/histai/hibou-L)  (`--patch_encoder hibou_l --patch_size 224 --mag 20`)

--- a/tests/test_patch_encoders.py
+++ b/tests/test_patch_encoders.py
@@ -95,7 +95,9 @@ class TestPatchEncoders(unittest.TestCase):
     def test_lunitvits8_forward(self):
         self._test_encoder_forward('lunit-vits8')
     
-    
+    def test_midnight12k_forward(self):
+        self._test_encoder_forward('midnight12k')
+        self._test_encoder_forward('midnight12k', return_type="cls+mean")
 
 if __name__ == '__main__':
     unittest.main()

--- a/trident/patch_encoder_models/__init__.py
+++ b/trident/patch_encoder_models/__init__.py
@@ -22,6 +22,7 @@ from trident.patch_encoder_models.load import (
     KaikoS16InferenceEncoder,
     KaikoS8InferenceEncoder,
     KaikoL14InferenceEncoder,
+    Midnight12kInferenceEncoder,
 )
 
 __all__ = [
@@ -48,4 +49,5 @@ __all__ = [
     "KaikoS16InferenceEncoder",
     "KaikoS8InferenceEncoder",
     "KaikoL14InferenceEncoder",
+    "Midnight12kInferenceEncoder",
 ]

--- a/trident/patch_encoder_models/load.py
+++ b/trident/patch_encoder_models/load.py
@@ -43,6 +43,7 @@ def encoder_factory(model_name: str, **kwargs):
             - "kaiko-vits16"
             - "kaiko-vitl14"
             - "lunit-vits8"
+            - "midnight12k"
 
         **kwargs: Optional keyword arguments passed directly to the encoder constructor. These
             may include parameters such as:

--- a/trident/patch_encoder_models/load.py
+++ b/trident/patch_encoder_models/load.py
@@ -1,6 +1,6 @@
 import traceback
 from abc import abstractmethod
-from typing import Optional
+from typing import Literal, Optional
 import torch
 import os 
 
@@ -99,6 +99,8 @@ def encoder_factory(model_name: str, **kwargs):
         enc = KaikoL14InferenceEncoder
     elif model_name == 'lunit-vits8':
         enc = LunitS8InferenceEncoder
+    elif model_name == 'midnight12k':
+        enc = Midnight12kInferenceEncoder
     else:
         raise ValueError(f"Unknown encoder name {model_name}")
 
@@ -1054,3 +1056,57 @@ class Conchv15InferenceEncoder(BasePatchEncoder):
 
         precision = torch.float16
         return model, eval_transform, precision
+
+
+class Midnight12kInferenceEncoder(BasePatchEncoder):
+    def _build(self, return_type: Literal["cls_token", "cls+mean"] = "cls_token"):
+        from transformers import AutoModel
+        from .utils.constants import KAIKO_MEAN, KAIKO_STD
+        from torchvision import transforms
+
+        self.enc_name = "midnight12k"
+        weights_path = self._get_weights_path()
+
+        if weights_path:
+            try:
+                model_dir = os.path.dirname(weights_path)
+                model = AutoModel.from_pretrained(model_dir)
+            except:
+                traceback.print_exc()
+                raise Exception(
+                    f"Failed to create Midnight-12k model from local checkpoint at '{weights_path}'. "
+                    "You can download the required `model.safetensors` and `config.json` from: https://huggingface.co/kaiko-ai/midnight."
+                )
+        else:
+            self.ensure_has_internet(self.enc_name)
+            try:
+                model = AutoModel.from_pretrained("kaiko-ai/midnight")
+            except:
+                traceback.print_exc()
+                raise Exception("Failed to download Midnight-12k model")
+
+        eval_transform = transforms.Compose(
+            [
+                transforms.Resize(224),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(mean=KAIKO_MEAN, std=KAIKO_STD),
+            ]
+        )
+
+        precision = torch.float32
+        self.return_type = return_type
+        return model, eval_transform, precision
+
+    def forward(self, x):
+        out = self.model(x).last_hidden_state
+        cls_token = out[:, 0, :]
+        if self.return_type == "cls_token":
+            return cls_token
+        elif self.return_type == "cls+mean":
+            patch_embeddings = out[:, 1:, :]
+            return torch.cat([cls_token, patch_embeddings.mean(1)], dim=-1)
+        else:
+            raise ValueError(
+                f"expected return_type to be one of 'cls_token' or 'cls+mean', but got '{self.return_type}'"
+            )


### PR DESCRIPTION
Hi @guillaumejaume,

This PR adds support for the Midnight-12k foundation model published by Kaiko AI.

Paper: [Training state-of-the-art pathology foundation models with orders of magnitude less data](https://arxiv.org/abs/2504.05186v1)
HuggingFace: [kaiko-ai/midnight](https://huggingface.co/kaiko-ai/midnight)
GitHub: [https://github.com/kaiko-ai/Midnight](https://github.com/kaiko-ai/Midnight)

I've also added test coverage and updated the readme. Please let me know if you would prefer any further changes.

Best,
Jake