### PR TITLE
Allow WSIPatcher viz without coord file + deprecate OpenslideWSIPatcher

### DIFF
--- a/trident/__init__.py
+++ b/trident/__init__.py
@@ -4,7 +4,7 @@ from trident.wsi_objects.OpenSlideWSI import OpenSlideWSI
 from trident.wsi_objects.CuCIMWSI import CuCIMWSI
 from trident.wsi_objects.ImageWSI import ImageWSI
 from trident.wsi_objects.WSIFactory import load_wsi, WSIReaderType
-from trident.wsi_objects.WSIPatcher import OpenSlideWSIPatcher
+from trident.wsi_objects.WSIPatcher import OpenSlideWSIPatcher, WSIPatcher
 from trident.wsi_objects.WSIPatcherDataset import WSIPatcherDataset
 
 from trident.Visualization import visualize_heatmap
@@ -21,6 +21,7 @@ __all__ = [
     "OpenSlideWSI", 
     "ImageWSI",
     "CuCIMWSI",
+    "WSIPatcher",
     "OpenSlideWSIPatcher",
     "WSIPatcherDataset",
     "visualize_heatmap",

--- a/trident/wsi_objects/WSIPatcher.py
+++ b/trident/wsi_objects/WSIPatcher.py
@@ -276,6 +276,8 @@ class WSIPatcher:
         # Get thumbnail in right format
         canvas = np.array(self.wsi.get_thumbnail((thumbnail_width, thumbnail_height))).astype(np.uint8)
 
+        tmp_coords = self.coords_only
+        self.coords_only = True
         # Draw rectangles for patches
         for (x, y) in self:
             x, y = int(x/downsample_factor), int(y/downsample_factor)
@@ -287,6 +289,8 @@ class WSIPatcher:
                 (255, 0, 0), 
                 thickness
             )
+
+        self.coords_only = tmp_coords
 
         # Add annotations
         text_area_height = 130


### PR DESCRIPTION
**Use case:**
- Sometimes we do not have coordinate files but we still want to visualize patches directly by calling WSIPatcher.visualize().

**Solution:**
- Move the visualization code to WSIPatcher –> since a WSIPatcher _has a_ WSI, the visualization method conceptually belongs in WSIPatcher

Also I'm changing OpenslideWSIPatcher -> WSIPatcher


This PR doesn't include any breaking changes
