### PR TITLE
Bug fix in wsi.py.

### DIFF
--- a/trident/wsi_objects/WSI.py
+++ b/trident/wsi_objects/WSI.py
@@ -326,7 +326,7 @@ class WSI:
         for imgs, (xcoords, ycoords) in dataloader:
 
             imgs = imgs.to(device, dtype=precision)  # Move to device and match dtype
-            with torch.autocast(device_type=device.split(":")[0], dtype=precision, enabled=(precision != torch.float32)):
+            with torch.autocast(device_type=(device).split(":")[0], dtype=precision, enabled=(precision != torch.float32)):
                 preds = segmentation_model(imgs).cpu().numpy()
 
             x_starts = np.clip(np.round(xcoords.numpy() * mpp_reduction_factor).astype(int), 0, width - 1) # clip for starts


### PR DESCRIPTION
device.split doesn't work because device must be a string, not a toch.device obj. This line solves it
The error is reproduced using the [tutorial 3](https://github.com/mahmoodlab/TRIDENT/blob/main/tutorials/3-Training-a-WSI-Classification-Model-with-ABMIL-and-Heatmaps.ipynb).