### PR TITLE
Add blur to visualization

### DIFF
--- a/tutorials/3-Training-a-WSI-Classification-Model-with-ABMIL-and-Heatmaps.ipynb
+++ b/tutorials/3-Training-a-WSI-Classification-Model-with-ABMIL-and-Heatmaps.ipynb
@@ -308,7 +308,9 @@
     "    patch_size_level0=coords_attrs['patch_size_level0'],\n",
     "    normalize=True,\n",
     "    num_top_patches_to_save=10,\n",
-    "    output_dir=job_dir\n",
+    "    output_dir=job_dir,\n",
+    "    blur=True,\n",
+    "    overlap=0.5\n",
     ")\n",
     "\n"
    ]


### PR DESCRIPTION
I added the blur and overlap (optional) parameters to control the display of the heatmaps. Also modified tutorial 3 to include these parameters in the last section.