### PR TITLE
Add ability to add custom models in usermodels.py

### DIFF
--- a/run_batch_of_slides.py
+++ b/run_batch_of_slides.py
@@ -11,7 +11,7 @@ import argparse
 import torch
 
 from trident import Processor 
-
+from trident.patch_encoder_models import encoder_registry
 
 def build_parser():
     """
@@ -86,11 +86,7 @@ def build_parser():
                         help='Directory to save/restore tissue coordinates.')
     # Feature extraction arguments 
     parser.add_argument('--patch_encoder', type=str, default='conch_v15', 
-                        choices=['conch_v1', 'uni_v1', 'uni_v2', 'ctranspath', 'phikon', 
-                                 'resnet50', 'gigapath', 'virchow', 'virchow2', 
-                                 'hoptimus0', 'hoptimus1', 'phikon_v2', 'conch_v15', 'musk', 'hibou_l',
-                                 'kaiko-vits8', 'kaiko-vits16', 'kaiko-vitb8', 'kaiko-vitb16',
-                                 'kaiko-vitl14', 'lunit-vits8', 'midnight12k'],
+                        choices=list(encoder_registry.keys()),
                         help='Patch encoder to use')
     parser.add_argument(
         '--patch_encoder_ckpt_path', type=str, default=None,

--- a/run_single_slide.py
+++ b/run_single_slide.py
@@ -11,7 +11,7 @@ import os
 
 from trident import load_wsi
 from trident.segmentation_models import segmentation_model_factory
-from trident.patch_encoder_models import encoder_factory
+from trident.patch_encoder_models import encoder_factory, encoder_registry
 
 
 def parse_arguments():
@@ -23,11 +23,7 @@ def parse_arguments():
     parser.add_argument("--slide_path", type=str, required=True, help="Path to the WSI file to process")
     parser.add_argument("--job_dir", type=str, required=True, help="Directory to store outputs")
     parser.add_argument('--patch_encoder', type=str, default='conch_v15', 
-                        choices=['conch_v1', 'uni_v1', 'uni_v2', 'ctranspath', 'phikon', 
-                                 'resnet50', 'gigapath', 'virchow', 'virchow2', 
-                                 'hoptimus0', 'hoptimus1', 'phikon_v2', 'conch_v15', 'musk', 'hibou_l',
-                                 'kaiko-vits8', 'kaiko-vits16', 'kaiko-vitb8', 'kaiko-vitb16',
-                                 'kaiko-vitl14', 'lunit-vits8'],
+                        choices=list(encoder_registry.keys()),
                         help='Patch encoder to use')
     parser.add_argument("--mag", type=int, choices=[5, 10, 20, 40], default=20,
                         help="Magnification at which patches/features are extracted")

--- a/trident/patch_encoder_models/__init__.py
+++ b/trident/patch_encoder_models/__init__.py
@@ -1,5 +1,10 @@
 from trident.patch_encoder_models.load import (
-    encoder_factory,
+    encoder_registry,
+    encoder_factory
+)
+
+
+from trident.patch_encoder_models.base import (
     CustomInferenceEncoder,
     MuskInferenceEncoder,
     Conchv1InferenceEncoder,
@@ -27,6 +32,7 @@ from trident.patch_encoder_models.load import (
 
 __all__ = [
     "encoder_factory",
+    "encoder_registry",
     "CustomInferenceEncoder",
     "MuskInferenceEncoder",
     "Conchv1InferenceEncoder",

--- a/trident/patch_encoder_models/base.py
+++ b/trident/patch_encoder_models/base.py
@@ -6,71 +6,102 @@ import os
 
 from trident.patch_encoder_models.utils.constants import get_constants
 from trident.patch_encoder_models.utils.transform_utils import get_eval_transforms
-from trident.patch_encoder_models.base import BasePatchEncoder,CustomInferenceEncoder
 from trident.IO import get_weights_path, has_internet_connection
-from trident.patch_encoder_models.base import encoder_registry as encoder_registry
-
-try:
-    from trident.patch_encoder_models.usermodels import encoder_registry as extra_models
-except ModuleNotFoundError as e:
-    extra_models = {}
-
-"""
-This file contains an assortment of pretrained patch encoders, all loadable via the encoder_factory() function.
-"""
 
 
-encoder_registry.update(extra_models)
+class BasePatchEncoder(torch.nn.Module):
 
-def encoder_factory(model_name: str, **kwargs):
-    """
-    Instantiate a patch encoder model by name.
+    _has_internet = has_internet_connection()
+    
+    def __init__(self, weights_path: Optional[str] = None, **build_kwargs):
+        """
+        Initialize BasePatchEncoder.
 
-    This factory function returns a pre-configured encoder model class based on the provided
-    `model_name`. Each encoder is designed for extracting representations from image patches
-    using specific backbones or pretraining strategies.
+        Args:
+            weights_path (Optional[str]): 
+                Optional path to local model weights. If None, the model is loaded from the model registry or downloaded from Hugging Face Hub.
+            **build_kwargs: 
+                Additional keyword arguments passed to the `_build()` method to customize model creation.
 
-    Args:
-        model_name (str): Name of the encoder to instantiate. Must be one of the following:
-            - "conch_v1"
-            - "conch_v15"
-            - "uni_v1"
-            - "uni_v2"
-            - "ctranspath"
-            - "phikon"
-            - "phikon_v2"
-            - "resnet50"
-            - "gigapath"
-            - "virchow"
-            - "virchow2"
-            - "hoptimus0"
-            - "hoptimus1"
-            - "musk"
-            - "hibou_l"
-            - "kaiko-vitb8"
-            - "kaiko-vitb16"
-            - "kaiko-vits8"
-            - "kaiko-vits16"
-            - "kaiko-vitl14"
-            - "lunit-vits8"
+        Attributes:
+            enc_name (Optional[str]): Name of the encoder architecture (set during `_build()`).
+            weights_path (Optional[str]): Path to local model weights (if provided).
+            model (nn.Module): The instantiated encoder model.
+            eval_transforms (Callable): Evaluation-time preprocessing transforms.
+            precision (torch.dtype): Precision used for inference.
+        """
 
-        **kwargs: Optional keyword arguments passed directly to the encoder constructor. These
-            may include parameters such as:
-            - weights_path (str): Path to a local checkpoint (optional)
-            - normalize (bool): Whether to normalize output embeddings (default: False)
-            - with_proj (bool): Whether to apply the projection head (default: True)
-            - any model-specific configuration parameters
+        super().__init__()
+        self.enc_name: Optional[str] = None
+        self.weights_path: Optional[str] = weights_path
+        self.model, self.eval_transforms, self.precision = self._build(**build_kwargs)
 
-    Returns:
-        torch.nn.Module: An instance of the specified encoder model.
+    def ensure_valid_weights_path(self, weights_path):
+        if weights_path and not os.path.isfile(weights_path):
+            raise FileNotFoundError(f"Expected checkpoint at '{weights_path}', but the file was not found.")
+    
+    def ensure_has_internet(self, enc_name):
+        if not BasePatchEncoder._has_internet:
+            raise FileNotFoundError(
+                f"Internet connection does seem not available. Auto checkpoint download is disabled."
+                f"To proceed, please manually download: {enc_name},\n"
+                f"and place it in the model registry in:\n`trident/patch_encoder_models/local_ckpts.json`"
+            )
+        
+    def _get_weights_path(self):
+        """
+        If self.weights_path is provided, use it. 
+        If not provided, check the model registry. 
+            If path in model registry is empty, auto-download from huggingface
+            else, use the path from the registry.
+        """
+        if self.weights_path:
+            self.ensure_valid_weights_path(self.weights_path)
+            return self.weights_path
+        else:
+            weights_path = get_weights_path('patch', self.enc_name)
+            self.ensure_valid_weights_path(weights_path)
+            return weights_path
 
-    Raises:
-        ValueError: If `model_name` is not among the recognized encoder names.
-    """
-    if model_name in encoder_registry:
-        return encoder_registry[model_name](**kwargs)
-    else:
-        raise ValueError(f"Unknown encoder name {model_name}")
+    def forward(self, x):
+        """
+        Can be overwritten if model requires special forward pass.
+        """
+        z = self.model(x)
+        return z
+        
+    @abstractmethod
+    def _build(self, **build_kwargs):
+        pass
+
+
+class CustomInferenceEncoder(BasePatchEncoder):
+
+    def __init__(self, enc_name, model, transforms, precision):
+        """
+        Initialize a CustomInferenceEncoder from user-defined components.
+
+        This class is used when the model, transforms, and precision are pre-instantiated externally 
+        and should be injected directly into the encoder wrapper.
+
+        Args:
+            enc_name (str): 
+                A unique name or identifier for the encoder (used for registry or logging).
+            model (torch.nn.Module): 
+                A PyTorch model instance to use for inference.
+            transforms (Callable): 
+                A callable (e.g., torchvision or timm transform) to preprocess input images for evaluation.
+            precision (torch.dtype): 
+                The precision to use for inference (e.g., torch.float32, torch.float16).
+        """
+        super().__init__()
+        self.enc_name = enc_name
+        self.model = model
+        self.eval_transforms = transforms
+        self.precision = precision
+        
+    def _build(self):
+        return None, None, None
 
 
 class MuskInferenceEncoder(BasePatchEncoder):
@@ -1124,3 +1155,26 @@ class Midnight12kInferenceEncoder(BasePatchEncoder):
             raise ValueError(
                 f"expected return_type to be one of 'cls_token' or 'cls+mean', but got '{self.return_type}'"
             )
+
+encoder_registry = {
+    "conch_v1": Conchv1InferenceEncoder,
+    "conch_v15": Conchv15InferenceEncoder,
+    "uni_v1": UNIInferenceEncoder,
+    "uni_v2": UNIv2InferenceEncoder,
+    "ctranspath": CTransPathInferenceEncoder,
+    "phikon": PhikonInferenceEncoder,
+    "resnet50": ResNet50InferenceEncoder,
+    "gigapath": GigaPathInferenceEncoder,
+    "virchow": VirchowInferenceEncoder,
+    "virchow2": Virchow2InferenceEncoder,
+    "hoptimus0": HOptimus0InferenceEncoder,
+    "hoptimus1": HOptimus1InferenceEncoder,
+    "musk": MuskInferenceEncoder,
+    "hibou_l": HibouLInferenceEncoder,
+    "kaiko-vitb8": KaikoB8InferenceEncoder,
+    "kaiko-vitb16": KaikoB16InferenceEncoder,
+    "kaiko-vits8": KaikoS8InferenceEncoder,
+    "kaiko-vits16": KaikoS16InferenceEncoder,
+    "kaiko-vitl14": KaikoL14InferenceEncoder,
+    "lunit-vits8": LunitS8InferenceEncoder,
+}

--- a/trident/patch_encoder_models/usermodels.py
+++ b/trident/patch_encoder_models/usermodels.py
@@ -1,0 +1,45 @@
+from trident.patch_encoder_models.base import encoder_registry as base_encoder_registry
+import torch
+import torchvision.transforms as transforms
+import pdb
+
+
+def build_class(base_model_class):
+    class DynamicModel(base_model_class):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.enc_name = self.enc_name + '_green'
+
+        def _build(self):
+
+            model, eval_transforms, precision = super()._build()
+
+            start_i=[i for i,t in enumerate(eval_transforms.transforms) if isinstance(t, transforms.ToTensor)]
+            if len(start_i) == 0:
+                raise('Cannot find ToTensor in patch_transforms')
+            start_i = start_i[0]
+            eval_transforms = transforms.Compose(eval_transforms.transforms[0:start_i+1] #ToTensor()                                                                                                     
+                                                    + [BoostGreen()]
+                                                    + eval_transforms.transforms[start_i+1:])
+            return model, eval_transforms, precision
+    return DynamicModel
+
+encoder_registry = {}                    
+for name, model in base_encoder_registry.items():
+        model=build_class(model)
+        encoder_registry[name+"_green"] = model
+
+class BoostGreen:
+    def __call__(self, img: torch.Tensor) -> torch.Tensor:
+        """                                                                                                                                                                                                
+        Assumes input is a tensor image with shape (C, H, W) and values in [0, 1].                                                                                                                         
+        Boosts the green channel by 20%, clips at 1.0.                                                                                                                                                     
+        """
+        if not isinstance(img, torch.Tensor):
+            raise TypeError("Input should be a torch.Tensor")
+
+        img = img.clone()  # avoid in-place modification                                                                                                                                                   
+        img[1] = torch.clamp(img[1] * 1.2, max=1.0)
+        return img
+
+


### PR DESCRIPTION
This is a first shot at:
https://github.com/mahmoodlab/TRIDENT/issues/94#issuecomment-3114510319

Specifically, I'm trying to reproduce some of the 'poisoned' datasets like the semi-synthetic one from this paper https://arxiv.org/html/2408.09449v1

Generally the idea is to create a usermodels.py that will allow for custom patch encoders to sit in one place and be automatically picked up and made available to run_batch_of_slide.py  and run_single_slide.py. 

(In my case I just recreate the existing models and insert a new argumentation into the eval_transforms stack. )

This PR creates a model_registry dictionary that picks up anything in patch_encoders.base.model_registry (derived from load.py) and patch_encoders.usermodels.model_registry, patch_encoders/load.py now combines these dictionaries and uses it in the factory function. 

I've included a patch_encoders/usermodels.py as an example of what I want to do, but the code should work if that's missing entirely. 

I'm not attached to this solution, so no worries if you want to do something else. 
