### PR TITLE
avoid loading encoder_weights for segmentation_models

### DIFF
--- a/trident/segmentation_models/load.py
+++ b/trident/segmentation_models/load.py
@@ -186,7 +186,6 @@ class GrandQCArtifactSegmenter(SegmentationModel):
         self.remove_penmarks_only = remove_penmarks_only  # ignore all other artifacts than penmakrs.
         model_ckpt_name = 'GrandQC_MPP1_state_dict.pth'
         encoder_name = 'timm-efficientnet-b0'
-        encoder_weights = 'imagenet'
         weights_path = get_weights_path('seg', 'grandqc_artifact')
 
         # Verify that user-provided weights_path is valid
@@ -198,7 +197,7 @@ class GrandQCArtifactSegmenter(SegmentationModel):
         # Initialize model
         model = smp.Unet(
             encoder_name=encoder_name,
-            encoder_weights=encoder_weights,
+            encoder_weights=None,
             classes=8,
             activation=None,
         )
@@ -275,7 +274,6 @@ class GrandQCSegmenter(SegmentationModel):
 
         model_ckpt_name = 'Tissue_Detection_MPP10.pth'
         encoder_name = 'timm-efficientnet-b0'
-        encoder_weights = 'imagenet'
         weights_path = get_weights_path('seg', 'grandqc') 
 
         # Verify that user-provided weights_path is valid
@@ -307,7 +305,7 @@ class GrandQCSegmenter(SegmentationModel):
         # Initialize model
         model = smp.UnetPlusPlus(
             encoder_name=encoder_name,
-            encoder_weights=encoder_weights,
+            encoder_weights=None,
             classes=2,
             activation=None,
         )


### PR DESCRIPTION
**Context:** 

Classes in `segmentation_models` currently load ImageNet weights by default.

**Problem:** 

This behavior attempts to download weights from the internet, which fails in environments without internet access. Because these weights are immediately replaced by those loaded from `weights_path`, this step is not necessary. Since `weights_path` can point to either a remote location or a local file, it does not create issues in offline use.

**Proposed Change:**

Set `encoder_weights=None` to avoid unnecessary downloads and ensure compatibility in offline settings.


