### PR TITLE
Fix mean-conch_v1 embedding dim

### DIFF
--- a/trident/slide_encoder_models/load.py
+++ b/trident/slide_encoder_models/load.py
@@ -463,7 +463,7 @@ class MeanSlideEncoder(BaseSlideEncoder):
         self.enc_name = model_name
         
         if model_name == 'mean-conch_v1':
-            embedding_dim = 768
+            embedding_dim = 512
         elif model_name == 'mean-conch_v15':
             embedding_dim = 768
         elif model_name == 'mean-uni_v1':


### PR DESCRIPTION
There is a mismatch between CONCH v1 embedding dim, which is 512, and mean-conch_v1 embedding dim, which is 768.
I have changed the embedding dim value of mean-conch_v1 from 768 to 512 to match the true embedding dim of CONCH v1.
This solves issue #143.