### PR TITLE
Expend SdpcWSI Format for TRIDENT

### DIFF
--- a/trident/wsi_objects/SdpcWSI
+++ b/trident/wsi_objects/SdpcWSI
@@ -1,0 +1,185 @@
+from __future__ import annotations
+import numpy as np
+import opensdpc
+from PIL import Image
+from typing import List, Tuple, Union, Optional
+from trident.wsi_objects.WSI import WSI, ReadMode
+
+
+class SdpcWSI(WSI):
+
+    def __init__(self, slide_path, **kwargs) -> None:
+        """
+        Initialize an SdpcWSI instance.
+
+        Parameters
+        ----------
+        slide_path : str
+            Path to the WSI file.
+        **kwargs : dict
+            Keyword arguments forwarded to the base `WSI` class. Most important key is:
+            - lazy_init (bool, default=True): Whether to defer loading WSI and metadata.
+
+        Please refer to WSI constructor for all parameters. 
+
+        Example
+        -------
+        >>> wsi = SdpcWSI(slide_path="path/to/wsi.svs", lazy_init=False)
+        >>> print(wsi)
+        <width=100000, height=80000, backend=SdpcWSI, mpp=0.25, mag=40>
+        """
+        super().__init__(slide_path, **kwargs)
+
+    def _lazy_initialize(self) -> None:
+        """
+        Lazily initialize the WSI using OpenSdpc.
+
+        This method opens a whole-slide image using the OpenSdpc backend, extracting
+        key metadata including dimensions, magnification, and multiresolution pyramid
+        information. If a tissue segmentation mask is provided, it is also loaded.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the WSI file or the tissue segmentation mask cannot be found.
+        Exception
+            If an unexpected error occurs during WSI initialization.
+
+        Notes
+        -----
+        After initialization, the following attributes are set:
+        - `width` and `height`: spatial dimensions of the base level.
+        - `dimensions`: (width, height) tuple from the highest resolution.
+        - `level_count`: number of resolution levels in the image pyramid.
+        - `level_downsamples`: downsampling factors for each level.
+        - `level_dimensions`: image dimensions at each level.
+        - `properties`: None for Sdpc Format.
+        - `mpp`: microns per pixel, inferred if not manually specified.
+        - `mag`: estimated magnification level.
+        - `gdf_contours`: loaded from `tissue_seg_path` if provided.
+        """
+
+        super()._lazy_initialize()
+
+        if not self.lazy_init:
+            try:
+                self.img = opensdpc.OpenSdpc(self.slide_path)
+                self.dimensions = self.get_dimensions()
+                self.width, self.height = self.dimensions
+                self.level_count = self.img.level_count
+                self.level_downsamples = self.img.level_downsamples
+                self.level_dimensions = self.img.level_dimensions
+                self.properties = None
+                if self.mpp is None:
+                    self.mpp = self.img.readSdpc(self.slide_path).contents.picHead.contents.ruler
+                self.mag = self.img.scan_magnification
+                self.lazy_init = True
+
+            except Exception as e:
+                raise RuntimeError(f"Failed to initialize WSI with OpenSdpc: {e}") from e
+
+    def _get_closed_thumbnail_level(self, size: Tuple[int, int]) -> int:
+        """
+        Determine the most appropriate pyramid level for generating a thumbnail
+        of the specified size.
+
+        Parameters
+        ----------
+        size : tuple of int
+            Desired (width, height) of the thumbnail.
+
+        Returns
+        -------
+        int
+            Pyramid level index that best matches the requested thumbnail size.
+
+        Notes
+        -----
+        This method selects the highest resolution level where both dimensions
+        are greater than or equal to the requested size. If no such level exists,
+        it returns the lowest resolution level (highest index).
+        """
+        for level in range(self.level_count):
+            level_width, level_height = self.level_dimensions[level]
+            if level_width <= size[0] and level_height <= size[1]:
+                return max(0, level - 1)
+        return self.level_count - 1
+
+    def read_region(
+        self,
+        location: Tuple[int, int],
+        level: int,
+        size: Tuple[int, int],
+        read_as: ReadMode = 'pil',
+    ) -> Union[Image.Image, np.ndarray]:
+        """
+        Extract a specific region from the whole-slide image (WSI).
+
+        Parameters
+        ----------
+        location : Tuple[int, int]
+            (x, y) coordinates of the top-left corner of the region to extract.
+        level : int
+            Pyramid level to read from.
+        size : Tuple[int, int]
+            (width, height) of the region to extract.
+        read_as : {'pil', 'numpy'}, optional
+            Output format for the region:
+            - 'pil': returns a PIL Image (default)
+            - 'numpy': returns a NumPy array (H, W, 3)
+
+        Returns
+        -------
+        Union[PIL.Image.Image, np.ndarray]
+            Extracted image region in the specified format.
+
+        Raises
+        ------
+        ValueError
+            If `read_as` is not one of 'pil' or 'numpy'.
+
+        Example
+        -------
+        >>> region = wsi.read_region((0, 0), level=0, size=(512, 512), read_as='numpy')
+        >>> print(region.shape)
+        (512, 512, 3)
+        """
+        region = self.img.read_region(location, level, size).convert('RGB')
+
+        if read_as == 'pil':
+            return region
+        elif read_as == 'numpy':
+            return np.array(region)
+        else:
+            raise ValueError(f"Invalid `read_as` value: {read_as}. Must be 'pil', 'numpy'.")
+
+    def get_dimensions(self) -> Tuple[int, int]:
+        """
+        Return the dimensions (width, height) of the WSI.
+
+        Returns
+        -------
+        tuple of int
+            (width, height) in pixels.
+        """
+        return self.img.level_dimensions[0]
+
+    def get_thumbnail(self, size: tuple[int, int]) -> Image.Image:
+        """
+        Generate a thumbnail of the WSI.
+
+        Parameters
+        ----------
+        size : tuple of int
+            Desired (width, height) of the thumbnail.
+
+        Returns
+        -------
+        PIL.Image.Image
+            RGB thumbnail as a PIL Image.
+        """
+        closest_level = self._get_closed_thumbnail_level(size)
+        level_width, level_height = self.level_dimensions[closest_level]
+        thumbnail = self.read_region((0, 0), closest_level, (level_width, level_height), read_as='pil')
+        thumbnail = thumbnail.resize(size, Image.LANCZOS)
+        return thumbnail

--- a/trident/wsi_objects/WSIFactory.py
+++ b/trident/wsi_objects/WSIFactory.py
@@ -5,16 +5,18 @@ from typing import Optional, Literal, Union
 from trident.wsi_objects.OpenSlideWSI import OpenSlideWSI
 from trident.wsi_objects.ImageWSI import ImageWSI
 from trident.wsi_objects.CuCIMWSI import CuCIMWSI
+from trident.wsi_objects.SdpcWSI import SdpcWSI
 
-WSIReaderType = Literal['openslide', 'image', 'cucim']
+WSIReaderType = Literal['openslide', 'image', 'cucim', 'sdpc']
 OPENSLIDE_EXTENSIONS = {'.svs', '.tif', '.tiff', '.ndpi', '.vms', '.vmu', '.scn', '.mrxs'}
 CUCIM_EXTENSIONS = {'.svs', '.tif', '.tiff'}
+SDPC_EXTENSIONS = {'.sdpc'}
 
 def load_wsi(
     slide_path: str,
     reader_type: Optional[WSIReaderType] = None,
     **kwargs
-) -> Union[OpenSlideWSI, ImageWSI, CuCIMWSI]:
+) -> Union[OpenSlideWSI, ImageWSI, CuCIMWSI, SdpcWSI]:
     """
     Load a whole-slide image (WSI) using the appropriate backend.
 
@@ -50,6 +52,15 @@ def load_wsi(
 
     elif reader_type == 'image':
         return ImageWSI(slide_path=slide_path, **kwargs)
+    
+    elif reader_type == 'sdpc':
+        if ext in SDPC_EXTENSIONS:
+            return SdpcWSI(slide_path=slide_path, **kwargs)
+        else:
+            raise ValueError(
+                f"Unsupported file format '{ext}' for SDPC. "
+                f"Supported whole-slide image formats are: {', '.join(SDPC_EXTENSIONS)}."
+            )
 
     elif reader_type == 'cucim':
         if ext in CUCIM_EXTENSIONS:
@@ -63,6 +74,8 @@ def load_wsi(
     elif reader_type is None:
         if ext in OPENSLIDE_EXTENSIONS:
             return OpenSlideWSI(slide_path=slide_path, **kwargs)
+        elif ext in SDPC_EXTENSIONS:
+            return SdpcWSI(slide_path=slide_path, **kwargs)
         else:
             return ImageWSI(slide_path=slide_path, **kwargs)
 


### PR DESCRIPTION
Dear Guillaume Jaume,

Your TRIDENT repository provides a versatile and general-purpose preprocessing pipeline for computational pathology. The SDPC format is a widely used open-source pathology image format. However, it is not currently supported by the OpenSlide framework, and instead relies on [OpenSDPC](https://github.com/WonderLandxD/opensdpc?utm_source=chatgpt.com)
 for image loading.

In this contribution, I have implemented SDPC format support into your unified WSI interface within TRIDENT. I have already verified the preprocessing functionality through testing. I will send you a sample SDPC file via email for your reference and further testing.

Thank you for your work, and I appreciate your time in reviewing this contribution.

Best regards,
Xitong Ling
lingxt23@mails.tsinghua.edu.cn