### PR TITLE
multi-GPU support v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Additional packages may be required to load some pretrained models. Follow error
 python run_batch_of_slides.py --task all --wsi_dir ./wsis --job_dir ./trident_processed --patch_encoder uni_v1 --mag 20 --patch_size 256
 ```
 
+Add `--gpus 0 1` (or any list of device indices) to split slides across multiple GPUs automatically.
+
 **Feeling cautious?**
 
 Run this command to perform all processing steps for a **single** slide:

--- a/run_batch_of_slides.py
+++ b/run_batch_of_slides.py
@@ -414,4 +414,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    mp.set_start_method('spawn', force=True)
     main()

--- a/run_batch_of_slides.py
+++ b/run_batch_of_slides.py
@@ -143,6 +143,52 @@ def generate_help_text() -> str:
     parser = build_parser()
     return parser.format_help()
 
+def _materialize_batch_csv(cache_batch_dir: str, original_csv_path: str) -> str:
+    """Create a per-batch CSV whose `wsi` entries match cached filenames.
+
+    Cache mode flattens slides into `cache_batch_dir` (basenames only). When a user
+    provides a CSV with nested relative paths and/or an `mpp` column, we generate a
+    filtered CSV for the current batch so `Processor` can still:
+      1) select exactly the batch slides, and
+      2) apply per-slide metadata like `mpp`.
+    """
+    import pandas as pd
+
+    df = pd.read_csv(original_csv_path)
+    if 'wsi' not in df.columns:
+        raise ValueError("CSV must contain a column named 'wsi'.")
+
+    cached_names = {
+        name
+        for name in os.listdir(cache_batch_dir)
+        if os.path.isfile(os.path.join(cache_batch_dir, name))
+    }
+    if not cached_names:
+        raise ValueError(f"Cache batch dir is empty: {cache_batch_dir}")
+
+    def _basename(p: Any) -> str:
+        # Handle NaNs and Windows-style separators.
+        s = str(p)
+        s = s.replace('\\\\', '/').replace('\\', '/')
+        return os.path.basename(s)
+
+    df = df.copy()
+    df['_wsi_basename'] = df['wsi'].map(_basename)
+
+    batch_df = df[df['_wsi_basename'].isin(cached_names)].copy()
+    if batch_df.empty:
+        raise ValueError(
+            "None of the slides in the custom CSV match the cached batch files. "
+            f"batch_dir={cache_batch_dir}, csv={original_csv_path}"
+        )
+
+    # Rewrite to basenames so `collect_valid_slides(cache_batch_dir, csv)` succeeds.
+    batch_df['wsi'] = batch_df['_wsi_basename']
+    batch_df.drop(columns=['_wsi_basename'], inplace=True)
+
+    out_csv = os.path.join(cache_batch_dir, '_trident_batch_wsis.csv')
+    batch_df.to_csv(out_csv, index=False)
+    return out_csv
 
 def initialize_processor(args: argparse.Namespace) -> Processor:
     """
@@ -340,7 +386,11 @@ def worker_entrypoint(args: argparse.Namespace) -> None:
             local_args = argparse.Namespace(**vars(args))
             local_args.wsi_dir = wsi_dir
             local_args.wsi_cache = None
-            local_args.custom_list_of_wsis = None
+            if local_args.custom_list_of_wsis:
+                local_args.custom_list_of_wsis = _materialize_batch_csv(
+                    cache_batch_dir=wsi_dir,
+                    original_csv_path=local_args.custom_list_of_wsis,
+                )
             local_args.search_nested = False
             local_args.selected_wsi_paths = None
             return initialize_processor(local_args)

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -1,0 +1,153 @@
+import unittest
+import sys
+import os
+import time
+import shutil
+import tempfile
+from unittest.mock import patch
+import torch
+
+import run_batch_of_slides as trident_run
+
+# ==========================================
+# USER CONFIGURATION
+# ==========================================
+# Path to a directory containing WSI files
+WSI_DIR = "/path/to/wsi/files"
+
+# GPU IDs to use (e.g., [0, 1])
+GPU_IDS = [0, 1] if torch.cuda.is_available() else [-1]
+
+# Trident task and model
+TASK = "all"
+PATCH_ENCODER = "conch_v15"
+
+# Inference and patch settings
+BATCH_SIZE = 32
+MAGNIFICATION = 20
+PATCH_SIZE = 512
+
+# Cache settings
+CACHE_BATCH_SIZE = 2
+
+# Misc
+SCRIPT_NAME = "trident_run.py"
+# ==========================================
+
+
+class TestTridentProfiling(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.exists(WSI_DIR):
+            raise FileNotFoundError(
+                f"Please update WSI_DIR in the test script. Path not found: {WSI_DIR}"
+            )
+
+        cls.task = TASK
+        cls.encoder = PATCH_ENCODER
+
+        print(f"\n=== Starting Profiling on {len(GPU_IDS)} GPU(s) ===")
+        print(f"Source: {WSI_DIR}")
+
+    def setUp(self):
+        # Fresh temp directories for each test
+        self.test_dir = tempfile.mkdtemp()
+        self.job_dir = os.path.join(self.test_dir, "job_output")
+        self.cache_dir = os.path.join(self.test_dir, "wsi_cache")
+        os.makedirs(self.job_dir, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def run_trident_scenario(self, run_name, gpus, use_cache=False):
+        """
+        Helper to run the trident main function with specific arguments.
+        """
+        print(f"\n[Running Scenario]: {run_name}")
+
+        args = [
+            SCRIPT_NAME,
+            "--wsi_dir", WSI_DIR,
+            "--job_dir", self.job_dir,
+            "--task", self.task,
+            "--patch_encoder", self.encoder,
+            "--batch_size", str(BATCH_SIZE),
+            "--mag", str(MAGNIFICATION),
+            "--patch_size", str(PATCH_SIZE),
+            "--gpus",
+        ] + [str(g) for g in gpus]
+
+        if use_cache:
+            args.extend([
+                "--wsi_cache", self.cache_dir,
+                "--cache_batch_size", str(CACHE_BATCH_SIZE),
+            ])
+
+        with patch.object(sys, "argv", args):
+            start_time = time.time()
+            try:
+                trident_run.main()
+            except SystemExit as e:
+                if e.code != 0:
+                    self.fail(f"Trident exited with error code {e.code}")
+            except Exception as e:
+                self.fail(f"Trident crashed: {e}")
+            end_time = time.time()
+
+        # Remove job output directory after each run
+        if os.path.exists(self.job_dir):
+            shutil.rmtree(self.job_dir)
+            os.makedirs(self.job_dir, exist_ok=True)
+
+        duration = end_time - start_time
+        print(f"[Completed]: {run_name} in {duration:.2f} seconds")
+        return duration
+
+    def test_benchmark_scenarios(self):
+        """
+        Run 4 scenarios (Single/Multi GPU × Cache/NoCache) and print a comparison.
+        """
+        results = {}
+
+        # 1. Single GPU - No Cache
+        results["1GPU_NoCache"] = self.run_trident_scenario(
+            "Single GPU | Direct Read",
+            gpus=[GPU_IDS[0]],
+            use_cache=False,
+        )
+
+        # 2. Single GPU - With Cache
+        results["1GPU_Cache"] = self.run_trident_scenario(
+            "Single GPU | Cached Read",
+            gpus=[GPU_IDS[0]],
+            use_cache=True,
+        )
+
+        # 3–4. Multi-GPU only if >1 GPU configured
+        if len(GPU_IDS) > 1:
+            results["MultiGPU_NoCache"] = self.run_trident_scenario(
+                f"{len(GPU_IDS)} GPUs | Direct Read",
+                gpus=GPU_IDS,
+                use_cache=False,
+            )
+
+            results["MultiGPU_Cache"] = self.run_trident_scenario(
+                f"{len(GPU_IDS)} GPUs | Cached Read",
+                gpus=GPU_IDS,
+                use_cache=True,
+            )
+
+        # Report
+        print("\n" + "=" * 40)
+        print(f"{'SCENARIO':<25} | {'TIME (s)':<10}")
+        print("-" * 40)
+        for name, duration in results.items():
+            print(f"{name:<25} | {duration:<10.2f}")
+        print("=" * 40)
+
+        self.assertTrue(all(t > 0 for t in results.values()))
+
+
+if __name__ == "__main__":
+    torch.multiprocessing.set_start_method("spawn", force=True)
+    unittest.main()

--- a/trident/Concurrency.py
+++ b/trident/Concurrency.py
@@ -69,7 +69,8 @@ def batch_producer(
         ssd_batch_dir = os.path.join(cache_dir, f"batch_{batch_id}")
         print(f"[PRODUCER] Caching batch {batch_id}: {ssd_batch_dir}")
         cache_batch(batch_paths, ssd_batch_dir)
-        queue.put(batch_id)
+        print(f"[PRODUCER] Batch {batch_id} cached and ready")
+        queue.put(batch_id)  # Put will block if queue is full (maxsize=1), enabling pipeline
 
     queue.put(None)  # Sentinel to signal completion
 
@@ -125,4 +126,5 @@ def batch_consumer(
 
             print(f"[CONSUMER] Clearing cache for batch {batch_id}")
             shutil.rmtree(ssd_batch_dir, ignore_errors=True)
-            queue.task_done()
+            print(f"[CONSUMER] Batch {batch_id} completed and cache cleared")
+            queue.task_done()  # Signal completion to producer

--- a/trident/IO.py
+++ b/trident/IO.py
@@ -910,6 +910,9 @@ def get_num_workers(batch_size: int,
     if os.name == 'nt':
         return 0
     
+    if max_workers is not None and max_workers <= 0:
+        return 0
+
     num_cores = os.cpu_count() or fallback
     num_workers = int(factor * num_cores)  # Use a fraction of available cores
     max_workers = max_workers or (2 * batch_size)  # Optional cap

--- a/trident/slide_encoder_models/load.py
+++ b/trident/slide_encoder_models/load.py
@@ -1,4 +1,4 @@
-2.5.import sys
+import sys
 import os
 import torch
 import traceback

--- a/trident/slide_encoder_models/load.py
+++ b/trident/slide_encoder_models/load.py
@@ -1,4 +1,4 @@
-import sys
+2.5.import sys
 import os
 import torch
 import traceback
@@ -330,14 +330,22 @@ class GigaPathSlideEncoder(BaseSlideEncoder):
             raise Exception("Please install fairscale and gigapath using `pip install fairscale git+https://github.com/prov-gigapath/prov-gigapath.git`.")
         
         # Make sure flash_attn is correct version
-        try:
-            import flash_attn; assert flash_attn.__version__ == '2.5.8'
-        except:
-            traceback.print_exc()
-            raise Exception("Please install flash_attn version 2.5.8 using `pip install flash_attn==2.5.8`.")
+        # try:
+        #     import flash_attn; assert flash_attn.__version__ == '2.5.8'
+        # except:
+        #     traceback.print_exc()
+        #     raise Exception("Please install flash_attn version 2.5.8 using `pip install flash_attn==2.5.8`.")
         
         if pretrained:
-            model = create_model("hf_hub:prov-gigapath/prov-gigapath", "gigapath_slide_enc12l768d", 1536, global_pool=True)
+            # Try to get local weights path first
+            weights_path = get_weights_path('slide', self.enc_name)
+            if weights_path:
+                print(f"Loading GigaPath slide encoder from local path: {weights_path}")
+                model = create_model(weights_path, "gigapath_slide_enc12l768d", 1536, global_pool=True)
+            else:
+                # Fallback to downloading from Hugging Face Hub
+                print("Local weights not found. Downloading from Hugging Face Hub...")
+                model = create_model("hf_hub:prov-gigapath/prov-gigapath", "gigapath_slide_enc12l768d", 1536, global_pool=True)
         else:
             model = create_model("", "gigapath_slide_enc12l768d", 1536, global_pool=True)
         

--- a/trident/wsi_objects/WSI.py
+++ b/trident/wsi_objects/WSI.py
@@ -18,10 +18,7 @@ from trident.IO import (
 
 ReadMode = Literal['pil', 'numpy']
 
-try:
-    _DATALOADER_MP_CTX = mp.get_context('fork') if 'fork' in mp.get_all_start_methods() else None
-except (ValueError, AttributeError):
-    _DATALOADER_MP_CTX = None
+_DATALOADER_MP_CTX = mp.get_context('spawn')
 
 
 class WSI:

--- a/trident/wsi_objects/WSI.py
+++ b/trident/wsi_objects/WSI.py
@@ -18,7 +18,10 @@ from trident.IO import (
 
 ReadMode = Literal['pil', 'numpy']
 
-_DATALOADER_MP_CTX = mp.get_context('spawn')
+try:
+    _DATALOADER_MP_CTX = mp.get_context('fork') if 'fork' in mp.get_all_start_methods() else None
+except (ValueError, AttributeError):
+    _DATALOADER_MP_CTX = None
 
 
 class WSI:


### PR DESCRIPTION
Hi! This PR is a tested multi-GPU inference practice with a test script `test_multigpu.py` (not a standalone unit test yet and need to run locally with a folder containing WSIs).
Our test result on 6 TCGA WSIs is as follows:

| SCENARIO       | TIME(s) |
|---------------|--------:|
| 1GPU_NoCache  |   74.07 |
| 1GPU_Cache    |   66.42 |
| 2GPU_NoCache | 48.30 |
| 2GPU_Cache   | 47.30 |

Features:
1. Enabling both WSI cache and non-cache mode with --gpus argument, by distributing all slide tasks equally on all allocated GPUs.
2. Auto skip completed slides when assigning tasks.
3. Clean stale .lock files and WSI caches before a run.
4. Support loading local Gigapath slide_encoder from local local_ckpts.json.

Feel free to test on your side to see if any bugs.
Thx!