### PR TITLE
feat: configurable patch encoder input resolution via dynamic_img_size

### DIFF
--- a/run_batch_of_slides.py
+++ b/run_batch_of_slides.py
@@ -315,13 +315,14 @@ def run_task(processor: Processor, args: argparse.Namespace) -> None:
         if args.slide_encoder is None: 
             from trident.patch_encoder_models.load import encoder_factory, RESIZE_SUPPORTED_PATCH_ENCODERS
             encoder_kwargs = {}
-            if args.patch_encoder_img_size is not None:
+            patch_encoder_img_size = getattr(args, "patch_encoder_img_size", None)
+            if patch_encoder_img_size is not None:
                 if args.patch_encoder not in RESIZE_SUPPORTED_PATCH_ENCODERS:
                     raise ValueError(
                         f"--patch_encoder_img_size is not supported for '{args.patch_encoder}'. "
                         f"It is only available for ViT-based encoders: {sorted(RESIZE_SUPPORTED_PATCH_ENCODERS)}."
                     )
-                encoder_kwargs['target_img_size'] = args.patch_encoder_img_size
+                encoder_kwargs['target_img_size'] = patch_encoder_img_size
             encoder = encoder_factory(args.patch_encoder, weights_path=args.patch_encoder_ckpt_path, **encoder_kwargs)
             mag_str = f"{float(args.mag):g}"
             processor.run_patch_feature_extraction_job(

--- a/run_batch_of_slides.py
+++ b/run_batch_of_slides.py
@@ -172,6 +172,16 @@ def build_parser() -> argparse.ArgumentParser:
             "`./trident/patch_encoder_models/local_ckpts.json`."
         )
     )
+    parser.add_argument(
+        '--patch_encoder_img_size', type=int, default=None,
+        help=(
+            "Optional custom input resolution (in pixels) for the patch encoder. When set, the "
+            "encoder resizes patches to this size and interpolates its positional embeddings "
+            "(timm `dynamic_img_size`). Must be a multiple of the model's patch size. Only "
+            "supported for ViT-based encoders; see `RESIZE_SUPPORTED_PATCH_ENCODERS`. Defaults to "
+            "the model's native resolution."
+        )
+    )
     parser.add_argument('--slide_encoder', type=str, default=None, 
                         choices=slide_encoder_registry.keys(), 
                         help='Slide encoder to use')
@@ -303,8 +313,16 @@ def run_task(processor: Processor, args: argparse.Namespace) -> None:
         )
     elif args.task == 'feat':
         if args.slide_encoder is None: 
-            from trident.patch_encoder_models.load import encoder_factory
-            encoder = encoder_factory(args.patch_encoder, weights_path=args.patch_encoder_ckpt_path)
+            from trident.patch_encoder_models.load import encoder_factory, RESIZE_SUPPORTED_PATCH_ENCODERS
+            encoder_kwargs = {}
+            if args.patch_encoder_img_size is not None:
+                if args.patch_encoder not in RESIZE_SUPPORTED_PATCH_ENCODERS:
+                    raise ValueError(
+                        f"--patch_encoder_img_size is not supported for '{args.patch_encoder}'. "
+                        f"It is only available for ViT-based encoders: {sorted(RESIZE_SUPPORTED_PATCH_ENCODERS)}."
+                    )
+                encoder_kwargs['target_img_size'] = args.patch_encoder_img_size
+            encoder = encoder_factory(args.patch_encoder, weights_path=args.patch_encoder_ckpt_path, **encoder_kwargs)
             mag_str = f"{float(args.mag):g}"
             processor.run_patch_feature_extraction_job(
                 coords_dir=args.coords_dir or f'{mag_str}x_{args.patch_size}px_{args.overlap}px_overlap',

--- a/run_single_slide.py
+++ b/run_single_slide.py
@@ -149,14 +149,15 @@ def process_slide(args):
         # Step 4: Feature Extraction
         print("Extracting features from patches...")
         encoder_kwargs = {}
-        if args.patch_encoder_img_size is not None:
+        patch_encoder_img_size = getattr(args, "patch_encoder_img_size", None)
+        if patch_encoder_img_size is not None:
             from trident.patch_encoder_models import RESIZE_SUPPORTED_PATCH_ENCODERS
             if args.patch_encoder not in RESIZE_SUPPORTED_PATCH_ENCODERS:
                 raise ValueError(
                     f"--patch_encoder_img_size is not supported for '{args.patch_encoder}'. "
                     f"It is only available for ViT-based encoders: {sorted(RESIZE_SUPPORTED_PATCH_ENCODERS)}."
                 )
-            encoder_kwargs['target_img_size'] = args.patch_encoder_img_size
+            encoder_kwargs['target_img_size'] = patch_encoder_img_size
         encoder = encoder_factory(args.patch_encoder, **encoder_kwargs)
         encoder.eval()
         encoder.to(f"cuda:{args.gpu}")

--- a/run_single_slide.py
+++ b/run_single_slide.py
@@ -27,6 +27,15 @@ def parse_arguments():
     parser.add_argument('--patch_encoder', type=str, default='conch_v15', 
                         choices=patch_encoder_registry.keys(),
                         help='Patch encoder to use')
+    parser.add_argument(
+        '--patch_encoder_img_size', type=int, default=None,
+        help=(
+            "Optional custom input resolution (in pixels) for the patch encoder. When set, the "
+            "encoder resizes patches to this size and interpolates its positional embeddings "
+            "(timm `dynamic_img_size`). Must be a multiple of the model's patch size. Only "
+            "supported for ViT-based encoders. Defaults to the model's native resolution."
+        )
+    )
     parser.add_argument("--mag", type=int, choices=[5, 10, 20, 40], default=20,
                         help="Magnification at which patches/features are extracted")
     parser.add_argument("--patch_size", type=int, default=256, help="Patch size at which coords/features are extracted")
@@ -139,7 +148,16 @@ def process_slide(args):
 
         # Step 4: Feature Extraction
         print("Extracting features from patches...")
-        encoder = encoder_factory(args.patch_encoder)
+        encoder_kwargs = {}
+        if args.patch_encoder_img_size is not None:
+            from trident.patch_encoder_models import RESIZE_SUPPORTED_PATCH_ENCODERS
+            if args.patch_encoder not in RESIZE_SUPPORTED_PATCH_ENCODERS:
+                raise ValueError(
+                    f"--patch_encoder_img_size is not supported for '{args.patch_encoder}'. "
+                    f"It is only available for ViT-based encoders: {sorted(RESIZE_SUPPORTED_PATCH_ENCODERS)}."
+                )
+            encoder_kwargs['target_img_size'] = args.patch_encoder_img_size
+        encoder = encoder_factory(args.patch_encoder, **encoder_kwargs)
         encoder.eval()
         encoder.to(f"cuda:{args.gpu}")
         features_path = features_dir = os.path.join(save_coords, "features_{}".format(args.patch_encoder))

--- a/tests/test_patch_encoder_resize.py
+++ b/tests/test_patch_encoder_resize.py
@@ -1,0 +1,177 @@
+import unittest
+from unittest.mock import patch
+
+import run_batch_of_slides as batch_mod
+import run_single_slide as single_mod
+from trident.patch_encoder_models import RESIZE_SUPPORTED_PATCH_ENCODERS
+from trident.patch_encoder_models.load import (
+    _resolve_target_img_size,
+    encoder_registry,
+)
+
+"""
+Unit tests for the configurable patch-encoder input resolution feature
+(`--patch_encoder_img_size` / `target_img_size`).
+
+These are deliberately lightweight: they exercise the pure validation helper,
+the supported-encoder registry, and the CLI plumbing/gating WITHOUT downloading
+weights or instantiating real models, so they run in CI with
+`TRIDENT_RUN_INTEGRATION_TESTS=0`. Forward-pass equivalence for the actual
+encoders lives in `tests/test_patch_encoders.py` behind the integration gate.
+"""
+
+
+class TestResolveTargetImgSize(unittest.TestCase):
+    def test_none_returns_default(self):
+        self.assertEqual(_resolve_target_img_size("enc", None, 224, 16), 224)
+        self.assertEqual(_resolve_target_img_size("enc", None, 518, 14), 518)
+
+    def test_valid_multiple_returned_unchanged(self):
+        self.assertEqual(_resolve_target_img_size("enc", 512, 224, 16), 512)
+        self.assertEqual(_resolve_target_img_size("enc", 448, 224, 14), 448)
+        # The default itself is always a valid multiple.
+        self.assertEqual(_resolve_target_img_size("enc", 224, 224, 16), 224)
+
+    def test_non_multiple_raises(self):
+        with self.assertRaises(AssertionError) as ctx:
+            _resolve_target_img_size("enc", 500, 224, 16)
+        # Error should mention the patch size and the encoder name to be useful.
+        msg = str(ctx.exception)
+        self.assertIn("enc", msg)
+        self.assertIn("16", msg)
+
+    def test_non_positive_raises(self):
+        for bad in (0, -16):
+            with self.assertRaises(AssertionError):
+                _resolve_target_img_size("enc", bad, 224, 16)
+
+    def test_non_integer_raises(self):
+        for bad in (512.0, "512"):
+            with self.assertRaises(AssertionError):
+                _resolve_target_img_size("enc", bad, 224, 16)
+
+
+class TestResizeSupportedRegistry(unittest.TestCase):
+    def test_supported_encoders_exist_in_registry(self):
+        """Every name advertised as resize-capable must be a real encoder."""
+        missing = sorted(n for n in RESIZE_SUPPORTED_PATCH_ENCODERS if n not in encoder_registry)
+        self.assertEqual(missing, [], f"Unknown encoder names in RESIZE_SUPPORTED_PATCH_ENCODERS: {missing}")
+
+    def test_set_is_non_empty(self):
+        self.assertGreater(len(RESIZE_SUPPORTED_PATCH_ENCODERS), 0)
+
+
+class TestParsersExposeFlag(unittest.TestCase):
+    def test_batch_parser_defaults_to_none(self):
+        parser = batch_mod.build_parser()
+        args = parser.parse_args(["--job_dir", "job", "--wsi_dir", "wsis"])
+        self.assertIsNone(args.patch_encoder_img_size)
+
+    def test_batch_parser_accepts_value(self):
+        parser = batch_mod.build_parser()
+        args = parser.parse_args([
+            "--job_dir", "job", "--wsi_dir", "wsis",
+            "--patch_encoder_img_size", "512",
+        ])
+        self.assertEqual(args.patch_encoder_img_size, 512)
+
+    def test_single_parser_defaults_to_none(self):
+        with patch("sys.argv", ["run_single_slide.py", "--slide_path", "x.svs",
+                                "--job_dir", "job"]):
+            args = single_mod.parse_arguments()
+        self.assertIsNone(args.patch_encoder_img_size)
+
+    def test_single_parser_accepts_value(self):
+        with patch("sys.argv", ["run_single_slide.py", "--slide_path", "x.svs",
+                                "--job_dir", "job", "--patch_encoder_img_size", "448"]):
+            args = single_mod.parse_arguments()
+        self.assertEqual(args.patch_encoder_img_size, 448)
+
+
+class _DummyProcessor:
+    def __init__(self):
+        self.calls = []
+
+    def run_patch_feature_extraction_job(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
+class TestRunTaskFeatGating(unittest.TestCase):
+    """`run_batch_of_slides.run_task` gating for `--patch_encoder_img_size`."""
+
+    def _feat_args(self, patch_encoder, img_size):
+        class Args:
+            pass
+
+        args = Args()
+        args.task = "feat"
+        args.device = "cpu"
+        args.slide_encoder = None
+        args.patch_encoder = patch_encoder
+        args.patch_encoder_ckpt_path = None
+        args.patch_encoder_img_size = img_size
+        args.mag = 20
+        args.patch_size = 256
+        args.overlap = 0
+        args.coords_dir = None
+        args.feat_batch_size = None
+        args.batch_size = 8
+        return args
+
+    def test_unsupported_encoder_with_img_size_raises(self):
+        # `conch_v15` is intentionally NOT in the resize-supported set.
+        self.assertNotIn("conch_v15", RESIZE_SUPPORTED_PATCH_ENCODERS)
+        processor = _DummyProcessor()
+        args = self._feat_args("conch_v15", img_size=512)
+
+        with patch("trident.patch_encoder_models.load.encoder_factory") as mock_factory:
+            with self.assertRaises(ValueError) as ctx:
+                batch_mod.run_task(processor, args)
+
+        self.assertIn("conch_v15", str(ctx.exception))
+        mock_factory.assert_not_called()
+        self.assertEqual(processor.calls, [])
+
+    def test_supported_encoder_forwards_target_img_size(self):
+        processor = _DummyProcessor()
+        args = self._feat_args("uni_v2", img_size=512)
+
+        with patch("trident.patch_encoder_models.load.encoder_factory") as mock_factory:
+            mock_factory.return_value = object()
+            batch_mod.run_task(processor, args)
+
+        mock_factory.assert_called_once()
+        _, kwargs = mock_factory.call_args
+        self.assertEqual(kwargs.get("target_img_size"), 512)
+        self.assertEqual(len(processor.calls), 1)
+
+    def test_no_img_size_does_not_forward_kwarg(self):
+        processor = _DummyProcessor()
+        args = self._feat_args("uni_v2", img_size=None)
+
+        with patch("trident.patch_encoder_models.load.encoder_factory") as mock_factory:
+            mock_factory.return_value = object()
+            batch_mod.run_task(processor, args)
+
+        mock_factory.assert_called_once()
+        _, kwargs = mock_factory.call_args
+        self.assertNotIn("target_img_size", kwargs)
+
+    def test_missing_attr_is_tolerated(self):
+        """Args constructed manually without the attribute must not crash
+        (mirrors the `getattr(args, ..., None)` guard added in the PR)."""
+        processor = _DummyProcessor()
+        args = self._feat_args("uni_v2", img_size=None)
+        del args.patch_encoder_img_size
+
+        with patch("trident.patch_encoder_models.load.encoder_factory") as mock_factory:
+            mock_factory.return_value = object()
+            batch_mod.run_task(processor, args)
+
+        mock_factory.assert_called_once()
+        _, kwargs = mock_factory.call_args
+        self.assertNotIn("target_img_size", kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_patch_encoders.py
+++ b/tests/test_patch_encoders.py
@@ -46,6 +46,28 @@ class TestPatchEncoders(unittest.TestCase):
         self.assertIsNotNone(output)
         self.assertIsInstance(output, torch.Tensor)
         print("\033[94m"+ f"    {encoder_name} forward pass success with output {output}" + "\033[0m")
+        return output
+
+    def _output_dim(self, encoder_name, **kwargs):
+        """Run a forward pass and return the embedding dimension (last axis)."""
+        output = self._test_encoder_forward(encoder_name, **kwargs)
+        return output.shape[-1]
+
+    def _test_encoder_resize(self, encoder_name, target_img_size):
+        """
+        Forward pass at a custom `target_img_size`, and assert the output
+        embedding dimension is unchanged vs. the native resolution. The encoders
+        pool over patch tokens, so a different input resolution changes the
+        number of tokens but must NOT change the feature dimensionality
+        (otherwise downstream feature files become incompatible).
+        """
+        native_dim = self._output_dim(encoder_name)
+        resized_dim = self._output_dim(encoder_name, target_img_size=target_img_size)
+        self.assertEqual(
+            native_dim, resized_dim,
+            f"{encoder_name}: embedding dim changed with target_img_size="
+            f"{target_img_size} ({native_dim} -> {resized_dim})",
+        )
 
     def test_conch_v1_forward(self):
         self._test_encoder_forward('conch_v1', with_proj = True, normalize = True)
@@ -136,6 +158,64 @@ class TestPatchEncoders(unittest.TestCase):
             out_b2 = encoder(torch.stack([x, x]))
         self.assertEqual(tuple(out_b1.shape), (1, 1152))
         self.assertEqual(tuple(out_b2.shape), (2, 1152))
+
+    # ------------------------------------------------------------------
+    # Configurable input resolution (`target_img_size` / dynamic_img_size).
+    # One representative encoder per distinct `_build` branch is exercised.
+    # target_img_size must be a multiple of each model's patch size.
+    # ------------------------------------------------------------------
+    def test_uni_v1_resize(self):
+        # patch_size 16 -> 448 is a multiple. Plain Resize/CenterCrop transform.
+        self._test_encoder_resize('uni_v1', target_img_size=448)
+
+    def test_uni_v2_resize(self):
+        # patch_size 14 -> 448 is a multiple.
+        self._test_encoder_resize('uni_v2', target_img_size=448)
+
+    def test_virchow_resize(self):
+        self._test_encoder_resize('virchow', target_img_size=448)
+
+    def test_virchow2_resize(self):
+        # Exercises the reg-token (output[:, 5:]) pooling path.
+        self._test_encoder_resize('virchow2', target_img_size=448)
+
+    def test_gigapath_resize(self):
+        # Exercises the branched eval-transform (target_img_size is not None).
+        self._test_encoder_resize('gigapath', target_img_size=448)
+
+    def test_hoptimus0_resize(self):
+        # Backbone default was dynamic_img_size=False; now flipped to True.
+        self._test_encoder_resize('hoptimus0', target_img_size=448)
+
+    def test_h0mini_resize(self):
+        # Exercises the resolve_model_data_config rewrite path + num_prefix_tokens.
+        self._test_encoder_resize('h0-mini', target_img_size=448)
+
+    def test_gpfm_resize(self):
+        self._test_encoder_resize('gpfm', target_img_size=448)
+
+    def test_lunitvits8_resize(self):
+        # patch_size 8; exercises the data_config crop_pct=1.0 rewrite path.
+        self._test_encoder_resize('lunit-vits8', target_img_size=448)
+
+    def test_kaiko_vitl14_resize(self):
+        # Special case: backbone built at 518, eval transform at 224 by default.
+        # patch_size 14 -> 448 is a multiple.
+        self._test_encoder_resize('kaiko-vitl14', target_img_size=448)
+
+    def test_kaiko_vits8_resize(self):
+        # patch_size 8 -> 256 is a multiple.
+        self._test_encoder_resize('kaiko-vits8', target_img_size=256)
+
+    def test_resize_rejects_non_multiple(self):
+        # 500 is not a multiple of UNI-v2's patch size (14): must fail loudly.
+        with self.assertRaises(AssertionError):
+            encoder_factory('uni_v2', target_img_size=500)
+
+    def test_resize_rejects_unsupported_encoder_path(self):
+        # conch_v15 has no target_img_size kwarg in its _build -> TypeError.
+        with self.assertRaises(TypeError):
+            encoder_factory('conch_v15', target_img_size=448)
 
 if __name__ == '__main__':
     unittest.main()

--- a/trident/patch_encoder_models/__init__.py
+++ b/trident/patch_encoder_models/__init__.py
@@ -1,6 +1,7 @@
 from trident.patch_encoder_models.load import (
     encoder_registry,
     encoder_factory,
+    RESIZE_SUPPORTED_PATCH_ENCODERS,
     CustomInferenceEncoder,
     MuskInferenceEncoder,
     Conchv1InferenceEncoder,
@@ -36,6 +37,7 @@ from trident.patch_encoder_models.load import (
 __all__ = [
     "encoder_registry",
     "encoder_factory",
+    "RESIZE_SUPPORTED_PATCH_ENCODERS",
     "CustomInferenceEncoder",
     "MuskInferenceEncoder",
     "Conchv1InferenceEncoder",

--- a/trident/patch_encoder_models/load.py
+++ b/trident/patch_encoder_models/load.py
@@ -12,6 +12,48 @@ from trident.IO import get_weights_path, has_internet_connection
 This file contains 20+ pretrained patch encoders, all loadable via the encoder_factory() function.
 """
 
+# Patch encoders that support a user-configurable input resolution via positional-embedding
+# interpolation (timm `dynamic_img_size`). For these models, a `target_img_size` keyword can be
+# forwarded through `encoder_factory(...)` into the encoder's `_build(...)`. See
+# `_resolve_target_img_size` for the validation rules.
+RESIZE_SUPPORTED_PATCH_ENCODERS = frozenset({
+    # Category A: dynamic_img_size already enabled on the timm backbone.
+    "uni_v1", "uni_v2", "virchow", "virchow2",
+    "kaiko-vitb8", "kaiko-vitb16", "kaiko-vits8", "kaiko-vits16", "kaiko-vitl14",
+    # Category B: dynamic_img_size enabled as part of this feature.
+    "gigapath", "hoptimus0", "hoptimus1", "gpfm", "lunit-vits8", "h0-mini",
+})
+
+
+def _resolve_target_img_size(enc_name: str, target_img_size: Optional[int], default_img_size: int, patch_size: int) -> int:
+    """
+    Validate and resolve a user-requested patch-encoder input resolution.
+
+    Parameters:
+        enc_name (str): Encoder name, used in error messages.
+        target_img_size (Optional[int]): Requested square input size in pixels. If None, the
+            model's native `default_img_size` is used.
+        default_img_size (int): Native training resolution of the encoder.
+        patch_size (int): ViT patch size. `target_img_size` must be an exact multiple of this so
+            positional embeddings can be interpolated without padding.
+
+    Returns:
+        int: The resolution to build the model and eval transform with.
+    """
+    if target_img_size is None:
+        return default_img_size
+    assert isinstance(target_img_size, int) and target_img_size > 0, (
+        f"{enc_name}: target_img_size must be a positive integer, got {target_img_size!r}."
+    )
+    assert target_img_size % patch_size == 0, (
+        f"{enc_name}: target_img_size={target_img_size} must be a multiple of the model patch size "
+        f"({patch_size}) so positional embeddings can be interpolated cleanly. "
+        f"Nearest valid sizes: {patch_size * (target_img_size // patch_size)} or "
+        f"{patch_size * (target_img_size // patch_size + 1)}."
+    )
+    return target_img_size
+
+
 def encoder_factory(model_name: str, **kwargs) -> torch.nn.Module:
     """
     Instantiate a patch encoder model by name.
@@ -500,6 +542,7 @@ class KaikoInferenceEncoder(BasePatchEncoder):
     MODEL_NAME = None  # set in subclasses
     HF_HUB_ID = None # set in subclasses
     IMG_SIZE = None
+    PATCH_SIZE = None  # set in subclasses
 
     def __init__(self, **build_kwargs):
         """
@@ -507,11 +550,17 @@ class KaikoInferenceEncoder(BasePatchEncoder):
         """
         super().__init__(**build_kwargs)
 
-    def _build(self):
+    def _build(self, target_img_size=None):
         import timm
         from torchvision.transforms import InterpolationMode
         self.enc_name = f"kaiko-{self.MODEL_NAME}"
         weights_path = self._get_weights_path()
+
+        # Default input resolution for Kaiko encoders is 224 (the eval transform size), even
+        # for the L14 variant whose backbone is built at 518. `model_img_size` preserves that
+        # original behavior when no custom size is requested.
+        transform_img_size = _resolve_target_img_size(self.enc_name, target_img_size, 224, self.PATCH_SIZE)
+        model_img_size = self.IMG_SIZE if target_img_size is None else transform_img_size
 
         if weights_path:
             try:
@@ -519,7 +568,7 @@ class KaikoInferenceEncoder(BasePatchEncoder):
                     f"{self.HF_HUB_ID}",
                     num_classes=0,
                     checkpoint_path=weights_path,
-                    img_size=self.IMG_SIZE,
+                    img_size=model_img_size,
                     dynamic_img_size=True
                 )
             except:
@@ -536,14 +585,14 @@ class KaikoInferenceEncoder(BasePatchEncoder):
                     dynamic_img_size=True,
                     pretrained=True,
                     num_classes=0,
-                    img_size=self.IMG_SIZE,
+                    img_size=model_img_size,
                 )
             except:
                 traceback.print_exc()
                 raise Exception("Failed to download Kaiko model.")
 
         mean, std = get_constants("kaiko")
-        eval_transform = get_eval_transforms(mean, std, target_img_size=224, center_crop=True, interpolation=InterpolationMode.BILINEAR, max_size=None, antialias=True)
+        eval_transform = get_eval_transforms(mean, std, target_img_size=transform_img_size, center_crop=True, interpolation=InterpolationMode.BILINEAR, max_size=None, antialias=True)
         precision = torch.float32
 
         return model, eval_transform, precision
@@ -556,6 +605,7 @@ class KaikoS16InferenceEncoder(KaikoInferenceEncoder):
     MODEL_NAME = "vits16"
     HF_HUB_ID = "vit_small_patch16_224"
     IMG_SIZE = 224
+    PATCH_SIZE = 16
 
     def __init__(self, **build_kwargs):
         """
@@ -568,6 +618,7 @@ class KaikoS8InferenceEncoder(KaikoInferenceEncoder):
     MODEL_NAME = "vits8"
     HF_HUB_ID = "vit_small_patch8_224"
     IMG_SIZE = 224
+    PATCH_SIZE = 8
 
     def __init__(self, **build_kwargs):
         """
@@ -580,6 +631,7 @@ class KaikoB16InferenceEncoder(KaikoInferenceEncoder):
     MODEL_NAME = "vitb16"
     HF_HUB_ID = "vit_base_patch16_224"
     IMG_SIZE = 224
+    PATCH_SIZE = 16
 
     def __init__(self, **build_kwargs):
         """
@@ -592,6 +644,7 @@ class KaikoB8InferenceEncoder(KaikoInferenceEncoder):
     MODEL_NAME = "vitb8"
     HF_HUB_ID = "vit_base_patch8_224"
     IMG_SIZE = 224
+    PATCH_SIZE = 8
 
     def __init__(self, **build_kwargs):
         """
@@ -604,6 +657,7 @@ class KaikoL14InferenceEncoder(KaikoInferenceEncoder):
     MODEL_NAME = "vitl14"
     HF_HUB_ID = "vit_large_patch14_reg4_dinov2"
     IMG_SIZE = 518
+    PATCH_SIZE = 14
 
     def __init__(self, **build_kwargs):
         """
@@ -690,17 +744,18 @@ class LunitS8InferenceEncoder(BasePatchEncoder):
         """
         super().__init__(**build_kwargs)
 
-    def _build(self):
+    def _build(self, target_img_size=None):
         import timm
         from timm.data import resolve_model_data_config
         from timm.data.transforms_factory import create_transform
 
         self.enc_name = 'lunit-vits8'
         weights_path = self._get_weights_path()
+        img_size = _resolve_target_img_size(self.enc_name, target_img_size, 224, 8)
 
         if weights_path:
             try:
-                timm_kwargs = {"img_size": 224}
+                timm_kwargs = {"img_size": img_size, "dynamic_img_size": True}
                 model = timm.create_model("vit_small_patch8_224", checkpoint_path=weights_path, **timm_kwargs)
             except:
                 traceback.print_exc()
@@ -711,12 +766,15 @@ class LunitS8InferenceEncoder(BasePatchEncoder):
         else:
             self.ensure_has_internet(self.enc_name)
             try:
-                model = timm.create_model("hf-hub:1aurent/vit_small_patch8_224.lunit_dino", pretrained=True)
+                model = timm.create_model("hf-hub:1aurent/vit_small_patch8_224.lunit_dino", pretrained=True, img_size=img_size, dynamic_img_size=True)
             except:
                 traceback.print_exc()
                 raise Exception("Failed to download Lunit S8 model, make sure that you were granted access and that you correctly registered your token.")
 
         data_config = resolve_model_data_config(model)
+        if target_img_size is not None:
+            data_config["input_size"] = (3, img_size, img_size)
+            data_config["crop_pct"] = 1.0
         eval_transform = create_transform(**data_config, is_training=False)
         precision = torch.float32
 
@@ -733,23 +791,25 @@ class UNIInferenceEncoder(BasePatchEncoder):
 
     def _build(
         self, 
-        timm_kwargs={"dynamic_img_size": True, "num_classes": 0, "init_values": 1e-5}
+        target_img_size=None,
     ):
         import timm
         from torchvision import transforms
 
         self.enc_name = 'uni_v1'
         weights_path = self._get_weights_path()
+        img_size = _resolve_target_img_size(self.enc_name, target_img_size, 224, 16)
+
+        timm_kwargs = {
+            'img_size': img_size,
+            'patch_size': 16,
+            'init_values': 1e-5,
+            'num_classes': 0,
+            'dynamic_img_size': True,
+        }
 
         if weights_path:
             try:
-                timm_kwargs = {
-                    'img_size': 224,
-                    'patch_size': 16,
-                    'init_values': 1e-5,
-                    'num_classes': 0,
-                    'dynamic_img_size': True,
-                }
                 model = timm.create_model("vit_large_patch16_224", **timm_kwargs)
                 model.load_state_dict(torch.load(weights_path, map_location="cpu"), strict=True)
             except:
@@ -767,8 +827,8 @@ class UNIInferenceEncoder(BasePatchEncoder):
                 raise Exception("Failed to download UNI model, make sure that you were granted access and that you correctly registered your token")
 
         eval_transform = transforms.Compose([
-            transforms.Resize(224),
-            transforms.CenterCrop(224),
+            transforms.Resize(img_size),
+            transforms.CenterCrop(img_size),
             transforms.ToTensor(),
             transforms.Normalize(mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225)),
         ])
@@ -785,15 +845,16 @@ class UNIv2InferenceEncoder(BasePatchEncoder):
         """
         super().__init__(**build_kwargs)
 
-    def _build(self):
+    def _build(self, target_img_size=None):
         import timm
         from torchvision import transforms
 
         self.enc_name = 'uni_v2'
         weights_path = self._get_weights_path()
+        img_size = _resolve_target_img_size(self.enc_name, target_img_size, 224, 14)
 
         timm_kwargs = {
-            'img_size': 224,
+            'img_size': img_size,
             'patch_size': 14,
             'depth': 24,
             'num_heads': 24,
@@ -827,8 +888,8 @@ class UNIv2InferenceEncoder(BasePatchEncoder):
                 raise Exception("Failed to download UNI v2 model, make sure that you were granted access and that you correctly registered your token")
 
         eval_transform = transforms.Compose([
-            transforms.Resize(224),
-            transforms.CenterCrop(224),
+            transforms.Resize(img_size),
+            transforms.CenterCrop(img_size),
             transforms.ToTensor(),
             transforms.Normalize(mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225)),
         ])
@@ -847,6 +908,7 @@ class GigaPathInferenceEncoder(BasePatchEncoder):
 
     def _build(
         self, 
+        target_img_size=None,
     ):
         import timm
         assert timm.__version__ == '0.9.16', f"Gigapath requires timm version 0.9.16, but found {timm.__version__}. Please install the correct version using `pip install timm==0.9.16`"
@@ -854,18 +916,21 @@ class GigaPathInferenceEncoder(BasePatchEncoder):
 
         self.enc_name = 'gigapath'
         weights_path = self._get_weights_path()
+        # GigaPath uses a 16px patch size (overriding the patch14 timm backbone name).
+        img_size = _resolve_target_img_size(self.enc_name, target_img_size, 224, 16)
 
         if weights_path:
             try:
                 timm_kwargs = {
-                    "img_size": 224,
+                    "img_size": img_size,
                     "in_chans": 3,
                     "patch_size": 16,
                     "embed_dim": 1536,
                     "depth": 40,
                     "num_heads": 24,
                     "mlp_ratio": 5.33334,
-                    "num_classes": 0
+                    "num_classes": 0,
+                    "dynamic_img_size": True,
                 }
                 model = timm.create_model("vit_giant_patch14_dinov2", pretrained=False, **timm_kwargs)
                 model.load_state_dict(torch.load(weights_path, map_location="cpu"), strict=True)
@@ -878,20 +943,30 @@ class GigaPathInferenceEncoder(BasePatchEncoder):
         else:
             self.ensure_has_internet(self.enc_name)
             try:
-                model = timm.create_model("hf_hub:prov-gigapath/prov-gigapath", pretrained=True)
+                model = timm.create_model("hf_hub:prov-gigapath/prov-gigapath", pretrained=True, img_size=img_size, dynamic_img_size=True)
             except:
                 traceback.print_exc()
                 raise Exception("Failed to download GigaPath model, make sure that you were granted access and that you correctly registered your token")
 
         mean, std = get_constants('imagenet')
-        eval_transform = transforms.Compose(
-            [
-                transforms.Resize(256, interpolation=transforms.InterpolationMode.BICUBIC),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(mean, std),
-            ]
-        )
+        if target_img_size is None:
+            eval_transform = transforms.Compose(
+                [
+                    transforms.Resize(256, interpolation=transforms.InterpolationMode.BICUBIC),
+                    transforms.CenterCrop(224),
+                    transforms.ToTensor(),
+                    transforms.Normalize(mean, std),
+                ]
+            )
+        else:
+            eval_transform = transforms.Compose(
+                [
+                    transforms.Resize(img_size, interpolation=transforms.InterpolationMode.BICUBIC),
+                    transforms.CenterCrop(img_size),
+                    transforms.ToTensor(),
+                    transforms.Normalize(mean, std),
+                ]
+            )
         precision = torch.float16
         return model, eval_transform, precision
 
@@ -908,7 +983,7 @@ class VirchowInferenceEncoder(BasePatchEncoder):
     def _build(
         self,
         return_cls=False,
-        timm_kwargs={'mlp_layer': timm.layers.SwiGLUPacked, 'act_layer': torch.nn.SiLU}
+        target_img_size=None,
     ):
         import timm
         import torchvision
@@ -916,19 +991,21 @@ class VirchowInferenceEncoder(BasePatchEncoder):
 
         self.enc_name = 'virchow'
         weights_path = self._get_weights_path()
+        img_size = _resolve_target_img_size(self.enc_name, target_img_size, 224, 14)
+
+        timm_kwargs = {
+            "img_size": img_size,
+            "init_values": 1e-5,
+            "num_classes": 0,
+            "mlp_ratio": 5.3375,
+            "global_pool": "",
+            "dynamic_img_size": True,
+            'mlp_layer': timm.layers.SwiGLUPacked,
+            'act_layer': torch.nn.SiLU,
+        }
 
         if weights_path:
             try:
-                timm_kwargs = {
-                    "img_size": 224,
-                    "init_values": 1e-5,
-                    "num_classes": 0,
-                    "mlp_ratio": 5.3375,
-                    "global_pool": "",
-                    "dynamic_img_size": True,
-                    'mlp_layer': timm.layers.SwiGLUPacked,
-                    'act_layer': torch.nn.SiLU,
-                }
                 model = timm.create_model("vit_huge_patch14_224", **timm_kwargs)
                 model.load_state_dict(state_dict=torch.load(weights_path, map_location="cpu"), strict=True)
             except:
@@ -947,7 +1024,7 @@ class VirchowInferenceEncoder(BasePatchEncoder):
 
         eval_transform = transforms.Compose(
             [
-                transforms.Resize(224, interpolation=torchvision.transforms.InterpolationMode.BICUBIC),
+                transforms.Resize(img_size, interpolation=torchvision.transforms.InterpolationMode.BICUBIC),
                 transforms.ToTensor(),
                 transforms.Normalize(mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225)),
             ]
@@ -981,7 +1058,7 @@ class Virchow2InferenceEncoder(BasePatchEncoder):
     def _build(
         self,
         return_cls=False,
-        timm_kwargs={'mlp_layer': timm.layers.SwiGLUPacked, 'act_layer': torch.nn.SiLU}
+        target_img_size=None,
     ):
         import timm
         import torchvision
@@ -989,20 +1066,22 @@ class Virchow2InferenceEncoder(BasePatchEncoder):
 
         self.enc_name = 'virchow2'
         weights_path = self._get_weights_path()
+        img_size = _resolve_target_img_size(self.enc_name, target_img_size, 224, 14)
+
+        timm_kwargs = {
+            "img_size": img_size,
+            "init_values": 1e-5,
+            "num_classes": 0,
+            "reg_tokens": 4,
+            "mlp_ratio": 5.3375,
+            "global_pool": "",
+            "dynamic_img_size": True,
+            'mlp_layer': timm.layers.SwiGLUPacked,
+            'act_layer': torch.nn.SiLU,
+        }
 
         if weights_path:
             try:
-                timm_kwargs = {
-                    "img_size": 224,
-                    "init_values": 1e-5,
-                    "num_classes": 0,
-                    "reg_tokens": 4,
-                    "mlp_ratio": 5.3375,
-                    "global_pool": "",
-                    "dynamic_img_size": True,
-                    'mlp_layer': timm.layers.SwiGLUPacked,
-                    'act_layer': torch.nn.SiLU,
-                }
                 model = timm.create_model("vit_huge_patch14_224", **timm_kwargs)
                 model.load_state_dict(torch.load(weights_path, map_location="cpu"), strict=True)
             except:
@@ -1021,7 +1100,7 @@ class Virchow2InferenceEncoder(BasePatchEncoder):
         
         eval_transform = transforms.Compose(
             [
-                transforms.Resize(224, interpolation=torchvision.transforms.InterpolationMode.BICUBIC),
+                transforms.Resize(img_size, interpolation=torchvision.transforms.InterpolationMode.BICUBIC),
                 transforms.ToTensor(),
                 transforms.Normalize(mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225)),
             ]
@@ -1053,7 +1132,7 @@ class HOptimus0InferenceEncoder(BasePatchEncoder):
 
     def _build(
         self,
-        timm_kwargs={'init_values': 1e-5, 'dynamic_img_size': False}
+        target_img_size=None,
     ):
         import timm
         assert timm.__version__ == '0.9.16', f"H-Optimus requires timm version 0.9.16, but found {timm.__version__}. Please install the correct version using `pip install timm==0.9.16`"
@@ -1061,16 +1140,18 @@ class HOptimus0InferenceEncoder(BasePatchEncoder):
 
         self.enc_name = 'hoptimus0'
         weights_path = self._get_weights_path()
+        img_size = _resolve_target_img_size(self.enc_name, target_img_size, 224, 14)
+
+        timm_kwargs = {
+            "num_classes": 0,
+            "img_size": img_size,
+            "global_pool": "token",
+            'init_values': 1e-5,
+            'dynamic_img_size': True,
+        }
 
         if weights_path:
             try:
-                timm_kwargs = {
-                    "num_classes": 0,
-                    "img_size": 224,
-                    "global_pool": "token",
-                    'init_values': 1e-5,
-                    'dynamic_img_size': False
-                }
                 model = timm.create_model("vit_giant_patch14_reg4_dinov2", **timm_kwargs)
                 model.load_state_dict(torch.load(weights_path, map_location="cpu"), strict=True)
             except:
@@ -1088,7 +1169,7 @@ class HOptimus0InferenceEncoder(BasePatchEncoder):
                 raise Exception("Failed to download HOptimus-0 model, make sure that you were granted access and that you correctly registered your token")
 
         eval_transform = transforms.Compose([
-            transforms.Resize(224),  
+            transforms.Resize(img_size),  
             transforms.ToTensor(),
             transforms.Normalize(
                 mean=(0.707223, 0.578729, 0.703617), 
@@ -1110,7 +1191,7 @@ class HOptimus1InferenceEncoder(BasePatchEncoder):
 
     def _build(
         self,
-        timm_kwargs={'init_values': 1e-5, 'dynamic_img_size': False},
+        target_img_size=None,
         **kwargs
     ):
         import timm
@@ -1119,16 +1200,18 @@ class HOptimus1InferenceEncoder(BasePatchEncoder):
 
         self.enc_name = 'hoptimus1'
         weights_path = self._get_weights_path()
+        img_size = _resolve_target_img_size(self.enc_name, target_img_size, 224, 14)
+
+        timm_kwargs = {
+            "num_classes": 0,
+            "img_size": img_size,
+            "global_pool": "token",
+            'init_values': 1e-5,
+            'dynamic_img_size': True,
+        }
 
         if weights_path:
             try:
-                timm_kwargs = {
-                    "num_classes": 0,
-                    "img_size": 224,
-                    "global_pool": "token",
-                    'init_values': 1e-5,
-                    'dynamic_img_size': False
-                }
                 model = timm.create_model("vit_giant_patch14_reg4_dinov2", **timm_kwargs)
                 model.load_state_dict(torch.load(weights_path, map_location="cpu"), strict=True)
             except:
@@ -1146,7 +1229,7 @@ class HOptimus1InferenceEncoder(BasePatchEncoder):
                 raise Exception("Failed to download HOptimus-1 model, make sure that you were granted access and that you correctly registered your token")
 
         eval_transform = transforms.Compose([
-            transforms.Resize(224),  
+            transforms.Resize(img_size),  
             transforms.ToTensor(),
             transforms.Normalize(
                 mean=(0.707223, 0.578729, 0.703617), 
@@ -1312,7 +1395,7 @@ class H0MiniInferenceEncoder(BasePatchEncoder):
         """
         super().__init__(**build_kwargs)
 
-    def _build(self, return_type: Literal["cls_token", "cls+mean"] = "cls_token"):
+    def _build(self, return_type: Literal["cls_token", "cls+mean"] = "cls_token", target_img_size=None):
         import timm
         from timm.data import resolve_model_data_config
         from timm.data.transforms_factory import create_transform
@@ -1320,6 +1403,7 @@ class H0MiniInferenceEncoder(BasePatchEncoder):
         self.enc_name = "h0-mini"
         weights_path = self._get_weights_path()
         self.return_type = return_type
+        img_size = _resolve_target_img_size(self.enc_name, target_img_size, 224, 14)
 
         if weights_path:
             raise NotImplementedError(
@@ -1334,6 +1418,8 @@ class H0MiniInferenceEncoder(BasePatchEncoder):
                 pretrained=True,
                 mlp_layer=timm.layers.SwiGLUPacked,
                 act_layer=torch.nn.SiLU,
+                img_size=img_size,
+                dynamic_img_size=True,
             )
         except Exception:
             traceback.print_exc()
@@ -1344,6 +1430,9 @@ class H0MiniInferenceEncoder(BasePatchEncoder):
 
         # timm>=0.9 expects the model instance directly here.
         data_config = resolve_model_data_config(model)
+        if target_img_size is not None:
+            data_config["input_size"] = (3, img_size, img_size)
+            data_config["crop_pct"] = 1.0
         eval_transform = create_transform(**data_config, is_training=False)
         precision = torch.float16
 
@@ -1440,13 +1529,14 @@ class GPFMInferenceEncoder(BasePatchEncoder):
         """
         super().__init__(**build_kwargs)
 
-    def _build(self):
+    def _build(self, target_img_size=None):
         import timm
         from huggingface_hub import hf_hub_download
         from torchvision.transforms import InterpolationMode
 
         self.enc_name = "gpfm"
         weights_path = self._get_weights_path()
+        img_size = _resolve_target_img_size(self.enc_name, target_img_size, 224, 14)
 
         if not weights_path:
             self.ensure_has_internet(self.enc_name)
@@ -1460,8 +1550,9 @@ class GPFMInferenceEncoder(BasePatchEncoder):
             model = timm.create_model(
                 "vit_large_patch14_dinov2.lvd142m",
                 pretrained=False,
-                img_size=224,
+                img_size=img_size,
                 init_values=1e-5,
+                dynamic_img_size=True,
             )
             state_dict = torch.load(weights_path, map_location="cpu", weights_only=False)
             if isinstance(state_dict, dict) and "state_dict" in state_dict:
@@ -1478,7 +1569,7 @@ class GPFMInferenceEncoder(BasePatchEncoder):
         eval_transform = get_eval_transforms(
             mean,
             std,
-            target_img_size=224,
+            target_img_size=img_size,
             interpolation=InterpolationMode.BICUBIC,
             max_size=None,
             antialias=True,


### PR DESCRIPTION
## Summary
Adds optional custom input resolution for ViT patch encoders via timm `dynamic_img_size` (interpolates positional embeddings at runtime instead of forcing 224px).

## Changes
- Enabled `dynamic_img_size` for: `gigapath`, `hoptimus0/1`, `gpfm`, `lunit-vits8`, `h0-mini`
- Added `target_img_size` build-kwarg to all supported ViTs (above + `uni_v1/v2`, `virchow/virchow2`, `kaiko-*`)
- Helper asserts requested size is a multiple of the model's patch size (suggests nearest valid sizes)
- Defaults unchanged when flag unset; CLI errors clearly if used on an unsupported encoder
- Drive-by fix: `virchow/virchow2` HF-hub path was dropping `dynamic_img_size`/`reg_tokens`/etc. — unified both load paths

## Not covered
Non-ViT / fixed-token backbones (`ctranspath` Swin, `musk`, `gemma4-*`, `conch_v1`, `keep`, …) and HF-`transformers` ViTs (`phikon*`, `hibou_l`, `midnight12k`) — would need different handling, out of scope.