### PR TITLE
Add CARE slide encoder integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Trident supports 5 slide encoders, loaded via a slide-level [`encoder_factory`](
 | **Madeleine** | conch_v1 | `--slide_encoder madeleine --patch_size 256 --mag 10` | [MahmoodLab/madeleine](https://huggingface.co/MahmoodLab/madeleine) |
 | **Feather** | conch_v15 | `--slide_encoder feather --patch_size 512 --mag 20` | [MahmoodLab/FEATHER](https://huggingface.co/MahmoodLab/abmil.base.conch_v15.pc108-24k) |
 | **Feather-UNI2** | uni_v2 | `--slide_encoder feather_uni_v2 --patch_size 256 --mag 20` | [MahmoodLab/FEATHER](https://huggingface.co/MahmoodLab/abmil.base.uni_v2.pc108-24k) |
+| **CARE** | conch_v15 | `--slide_encoder care --patch_size 512 --mag 20` | [Zipper-1/CARE](https://huggingface.co/Zipper-1/CARE) |
 
 > [!NOTE]
 > If your task includes multiple slides per patient, you can generate patient-level embeddings by: (1) processing each slide independently and taking their average slide embedding (late fusion) or (2) pooling all patches together and processing that as a single "pseudo-slide" (early fusion). For an implementation of both fusion strategies, please check out our sister repository [Patho-Bench](https://github.com/mahmoodlab/Patho-Bench).

--- a/tests/test_slide_encoders.py
+++ b/tests/test_slide_encoders.py
@@ -59,6 +59,15 @@ class TestSlideEncoders(unittest.TestCase):
         }
         self._test_encoder_forward(TitanSlideEncoder(), sample_batch, torch.float16)
         
+    def test_care_encoder_initialization(self):
+        sample_batch = {
+            'features': torch.randn(1, 100, 768),
+            'coords': torch.randint(0, 512 * 100, (1, 100, 2)),
+            'attributes': {'patch_size_level0': 512}
+        }
+
+        self._test_encoder_forward(CARESlideEncoder(), sample_batch, torch.float32)
+
     def test_gigapath_encoder_initialization(self):
         sample_batch = {
             'features': torch.randn(1, 100, 1536),

--- a/trident/slide_encoder_models/__init__.py
+++ b/trident/slide_encoder_models/__init__.py
@@ -11,7 +11,8 @@ from trident.slide_encoder_models.load import (
     ThreadsSlideEncoder,
     MadeleineSlideEncoder,
     FeatherSlideEncoder,
-    FeatherUni2SlideEncoder
+    FeatherUni2SlideEncoder,
+    CARESlideEncoder
 )
 
 __all__ = [
@@ -26,5 +27,6 @@ __all__ = [
     "CHIEFSlideEncoder",
     "GigaPathSlideEncoder",
     "FeatherSlideEncoder",
-    "FeatherUni2SlideEncoder"
+    "FeatherUni2SlideEncoder",
+    "CARESlideEncoder"
 ]

--- a/trident/slide_encoder_models/load.py
+++ b/trident/slide_encoder_models/load.py
@@ -49,7 +49,8 @@ slide_to_patch_encoder_name = {
     'gigapath': 'gigapath',
     'madeleine': 'conch_v1',
     'feather': 'conch_v15',
-    'feather_uni_v2': 'uni_v2'
+    'feather_uni_v2': 'uni_v2',
+    'care': 'conch_v15',
 }
 
 
@@ -409,6 +410,52 @@ class ThreadsSlideEncoder(BaseSlideEncoder):
         pass
 
 
+class CARESlideEncoder(BaseSlideEncoder):
+    def __init__(self, **build_kwargs):
+        """CARE slide encoder initialization."""
+        super().__init__(**build_kwargs)
+
+    def _build(self, pretrained=True):
+        self.enc_name = 'care'
+        assert pretrained, "CARESlideEncoder has no non-pretrained model. Please load with pretrained=True."
+
+        from transformers import AutoModel
+        try:
+            model = AutoModel.from_pretrained(
+                "Zipper-1/CARE",
+                trust_remote_code=True
+            )
+        except Exception:
+            traceback.print_exc()
+            raise Exception(
+                "Failed to load CARE from Hugging Face. "
+                "Please make sure you have accepted access conditions for Zipper-1/CARE "
+                "and logged in with `huggingface-cli login`."
+            )
+
+        precision = torch.float32
+        embedding_dim = 512
+        return model, precision, embedding_dim
+
+    def forward(self, batch, device='cuda'):
+        features = batch['features'].to(device)
+        coords = batch['coords'].to(device)
+        patch_size = batch['attributes']['patch_size_level0']
+        coords = coords // int(patch_size)
+        if features.dim() == 2:
+            features = features.unsqueeze(0)
+        if coords.dim() == 2:
+            coords = coords.unsqueeze(0)
+        N_values = torch.full(
+            (features.shape[0],),
+            features.shape[1],
+            dtype=torch.long,
+            device=features.device
+        )
+        out = self.model(features, N_values, coords)
+        return out.wsi_embedding
+
+
 class TitanSlideEncoder(BaseSlideEncoder):
     
     def __init__(self, **build_kwargs):
@@ -563,6 +610,7 @@ encoder_registry = {
     'madeleine': MadeleineSlideEncoder,
     'feather': FeatherSlideEncoder,
     'feather_uni_v2': FeatherUni2SlideEncoder,
+    'care': CARESlideEncoder,
     'abmil': ABMILSlideEncoder,
 
     # Mean encoders


### PR DESCRIPTION
This PR adds CARE as a slide-level encoder to TRIDENT.

Main changes:
- Added CARESlideEncoder in trident/slide_encoder_models/load.py
- Registered CARE in encoder_registry
- Added slide_to_patch_encoder_name mapping: care -> conch_v15
- Added README usage entry for CARE
- CARE outputs a 512-dimensional slide-level embedding

CARE uses CONCH v1.5 patch features and grid-level coordinates. The wrapper follows the official CARE Hugging Face interface by passing patch embeddings, N_values, and coordinates to the model, and returning out.wsi_embedding.