### PR TITLE
Feat/mrxs tests and segmentation messaging

### DIFF
--- a/tests/test_openslidewsi.py
+++ b/tests/test_openslidewsi.py
@@ -31,6 +31,8 @@ class TestOpenSlideWSI(unittest.TestCase):
         "TCGA-AN-A0XW-01Z-00-DX1.811E11E7-FA67-46BB-9BC6-1FD0106B789D.svs",
         "TCGA-B6-A0IJ-01Z-00-DX1.BF2E062F-06DA-4CA8-86C4-36674C035CAA.svs"
     ]
+    # MRXS (MIRAX) slide: a `.mrxs` index file plus a sibling data folder of the same name.
+    TEST_MRXS_SLIDE = os.path.join("CMU-1", "CMU-1.mrxs")
     TEST_OUTPUT_DIR = "test_single_slide_processing/"
     TEST_PATCH_ENCODER = "uni_v1"
     TEST_MAG = 20
@@ -114,6 +116,52 @@ class TestOpenSlideWSI(unittest.TestCase):
                 len(files), expected_file_count,
                 f"Expected {expected_file_count} files in '{output_dir}', but found {len(files)}."
             )
+
+    def test_mrxs_integration(self):
+        """
+        Test that an MRXS (MIRAX) slide can be read and processed end-to-end.
+
+        MRXS is a multi-file format (a `.mrxs` index file plus a sibling data
+        folder), so it exercises a different OpenSlide read path than the
+        single-file `.svs` slides above. Outputs are written to a dedicated
+        directory to avoid clashing with `test_integration`.
+        """
+        slide_path = os.path.join(self.local_wsi_dir, self.TEST_MRXS_SLIDE)
+        self.assertTrue(os.path.exists(slide_path), f"MRXS slide not found at {slide_path}.")
+
+        output_dir = os.path.join(self.TEST_OUTPUT_DIR, "mrxs")
+        os.makedirs(output_dir, exist_ok=True)
+
+        with load_wsi(slide_path=slide_path, lazy_init=False) as slide:
+            # Step 0: Metadata read from the `.mrxs` index + sibling data folder
+            self.assertEqual(len(slide.dimensions), 2)
+            self.assertTrue(all(dim > 0 for dim in slide.dimensions), "MRXS slide reported non-positive dimensions.")
+            self.assertGreater(slide.mag, 0, "MRXS slide reported non-positive magnification.")
+            self.assertGreater(slide.mpp, 0, "MRXS slide reported non-positive mpp.")
+            self.assertGreaterEqual(slide.level_count, 1)
+
+            # Step 1: Tissue segmentation
+            segmentation_model = segmentation_model_factory("hest")
+            slide.segment_tissue(segmentation_model=segmentation_model, target_mag=10, job_dir=output_dir, device=self.TEST_DEVICE)
+
+            # Step 2: Tissue coordinate extraction
+            coords_path = slide.extract_tissue_coords(
+                target_mag=self.TEST_MAG,
+                patch_size=self.TEST_PATCH_SIZE,
+                save_coords=output_dir
+            )
+
+            # Step 3: Visualization
+            viz_coords_path = slide.visualize_coords(
+                coords_path=coords_path,
+                save_patch_viz=os.path.join(output_dir, "visualization")
+            )
+
+        # Verify outputs
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "contours_geojson")), "GDF contours were not saved.")
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "contours")), "Contours were not saved.")
+        self.assertTrue(os.path.exists(coords_path), "Tissue coordinates file was not saved.")
+        self.assertTrue(os.path.exists(viz_coords_path), "Visualization file was not saved.")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_run_batch_of_slides_integration_outputs.py
+++ b/tests/test_run_batch_of_slides_integration_outputs.py
@@ -249,6 +249,162 @@ class TestRunBatchOfSlidesIntegrationOutputs(unittest.TestCase):
             created = [p for p in features_dir.iterdir() if p.suffix == ".h5"]
             self.assertEqual(len(created), 2, "Expected exactly 2 feature files for the 2 WSIs")
 
+    def test_otsu_penmarks_5x_uni_all_outputs(self):
+        """
+        Single `--task all` invocation that chains, in one run:
+          * otsu tissue segmentation        (`--segmenter otsu`)
+          * GrandQC penmark detection        (`--remove_penmarks`)
+          * 256x256 patching at 5x           (`--mag 5 --patch_size 256`)
+          * UNI feature extraction           (`--patch_encoder uni_v1`)
+
+        Runs over a mix of single-file `.svs` slides and a multi-file `.mrxs`
+        (MIRAX) slide to exercise both reader paths through the batch pipeline.
+        MRXS slides are laid out exactly like every other format: the `.mrxs`
+        index file(s) sit directly in `wsi_dir`, each alongside its same-named
+        data folder, and the custom list references them by basename. This keeps
+        slide discovery identical to single-file formats.
+
+        `--remove_penmarks` is used rather than `--remove_artifacts`: the full
+        artifact remover is aggressive enough to discard all of CMU-1's tissue,
+        whereas penmark-only removal preserves it.
+
+        Asserts that segmentation, coords, and feature outputs are all produced
+        by the single run and are mutually consistent (one feature row per patch,
+        UNI's 1024-d embedding).
+        """
+        import csv as csv_mod
+        import shutil
+        import run_batch_of_slides as rbs
+        import h5py
+        from huggingface_hub import snapshot_download
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wsi_dir = tmp_path / "wsis"
+            job_dir = tmp_path / "job"
+            wsi_dir.mkdir(parents=True, exist_ok=True)
+            job_dir.mkdir(parents=True, exist_ok=True)
+
+            # Single-file SVS fixtures: dropped directly into wsi_dir.
+            svs_names = self._pick_two_svs()
+            for filename in svs_names:
+                hf_hub_download(
+                    repo_id=self.HF_REPO,
+                    repo_type="dataset",
+                    filename=filename,
+                    local_dir=str(wsi_dir),
+                )
+
+            # Multi-file MRXS fixture. The repo stores it nested as
+            # `CMU-1/CMU-1.mrxs` + `CMU-1/CMU-1/<data>`; flatten it into the
+            # standard MIRAX layout so it sits in wsi_dir like the SVS files:
+            #   wsi_dir/CMU-1.mrxs          (index file)
+            #   wsi_dir/CMU-1/<data files>  (same-named sibling data folder)
+            staging = snapshot_download(
+                repo_id=self.HF_REPO,
+                repo_type="dataset",
+                allow_patterns=["CMU-1/*"],
+            )
+            shutil.copy(os.path.join(staging, "CMU-1", "CMU-1.mrxs"), wsi_dir / "CMU-1.mrxs")
+            shutil.copytree(os.path.join(staging, "CMU-1", "CMU-1"), wsi_dir / "CMU-1")
+            self.assertTrue((wsi_dir / "CMU-1.mrxs").is_file(), "MRXS index file not laid out in wsi_dir.")
+            self.assertTrue((wsi_dir / "CMU-1").is_dir(), "MRXS data folder not laid out alongside index.")
+
+            # Custom list: 'wsi' column holds basenames relative to wsi_dir,
+            # identical handling for single-file and multi-file formats.
+            slide_names = [*svs_names, "CMU-1.mrxs"]
+            csv_path = tmp_path / "wsis.csv"
+            with csv_path.open("w", newline="", encoding="utf-8") as f:
+                writer = csv_mod.DictWriter(f, fieldnames=["wsi"])
+                writer.writeheader()
+                for name in slide_names:
+                    writer.writerow({"wsi": name})
+
+            # Output stems are basenames without extension (e.g. "CMU-1").
+            expected_stems = [os.path.splitext(os.path.basename(p))[0] for p in slide_names]
+
+            mag, patch_size, overlap = 5, 256, 0
+            # Use GPU when available (GrandQC + UNI are deep models); fall back to
+            # CPU so the test stays runnable on CPU-only hosts.
+            gpu_arg = "0" if torch.cuda.is_available() else "-1"
+            argv = [
+                "run_batch_of_slides.py",
+                "--task", "all",
+                "--job_dir", str(job_dir),
+                "--wsi_dir", str(wsi_dir),
+                "--custom_list_of_wsis", str(csv_path),
+                "--wsi_ext", ".svs", ".mrxs",
+                "--segmenter", "otsu",
+                "--remove_penmarks",
+                "--patch_encoder", "uni_v1",
+                "--mag", str(mag),
+                "--patch_size", str(patch_size),
+                "--overlap", str(overlap),
+                "--batch_size", "2",
+                "--seg_batch_size", "2",
+                "--feat_batch_size", "2",
+                "--max_workers", "1",
+                "--gpus", gpu_arg,
+                "--skip_errors",
+            ]
+            rbs.sys.argv = argv
+            rbs.main()
+
+            mag_str = f"{float(mag):g}"
+            coords_dir = f"{mag_str}x_{patch_size}px_{overlap}px_overlap"
+
+            # 1) Segmentation outputs (otsu + grandqc penmark pass).
+            contours_dir = job_dir / "contours"
+            contours_geojson_dir = job_dir / "contours_geojson"
+            self.assertTrue(contours_dir.is_dir(), "Missing `contours/` output dir")
+            self.assertTrue(contours_geojson_dir.is_dir(), "Missing `contours_geojson/` output dir")
+
+            # 2) Coords outputs (256px @ 5x).
+            patches_dir = job_dir / coords_dir / "patches"
+            self.assertTrue(patches_dir.is_dir(), "Missing patch coords `patches/` output dir")
+
+            # 3) Feature outputs (UNI v1).
+            features_dir = job_dir / coords_dir / "features_uni_v1"
+            self.assertTrue(features_dir.is_dir(), "Missing patch features `features_uni_v1/` output dir")
+
+            for stem in expected_stems:
+                # Segmentation artifacts.
+                self.assertTrue((contours_dir / f"{stem}.jpg").exists(), f"Missing contour jpg for {stem}")
+                self.assertTrue(
+                    (contours_geojson_dir / f"{stem}.geojson").exists(),
+                    f"Missing contour geojson for {stem}",
+                )
+
+                # Coords: derive patch count dynamically (depends on tissue after
+                # artifact removal) rather than hard-coding a magic number.
+                coords_fp = patches_dir / f"{stem}_patches.h5"
+                self.assertTrue(coords_fp.exists(), f"Missing coords h5 for {stem}")
+                with h5py.File(coords_fp, "r") as f:
+                    self.assertIn("coords", f, f"coords dataset missing for {stem}")
+                    n_patches = int(f["coords"].shape[0])
+                    self.assertEqual(int(f["coords"].shape[1]), 2, f"coords should be (N, 2) for {stem}")
+                    self.assertGreater(n_patches, 0, f"Expected >0 patches for {stem}")
+                    self.assertEqual(int(f["coords"].attrs["patch_size"]), patch_size)
+                    self.assertEqual(int(f["coords"].attrs.get("overlap", 0)), overlap)
+
+                # Features: one 1024-d UNI row per patch coordinate.
+                feats_fp = features_dir / f"{stem}.h5"
+                self.assertTrue(feats_fp.exists(), f"Missing features h5 for {stem}")
+                with h5py.File(feats_fp, "r") as f:
+                    self.assertIn("features", f, f"features dataset missing for {stem}")
+                    feats = f["features"]
+                    self.assertEqual(
+                        int(feats.shape[0]),
+                        n_patches,
+                        f"features/coords count mismatch for {stem}",
+                    )
+                    self.assertEqual(int(feats.shape[1]), 1024, "UNI v1 embedding dim should be 1024")
+                    self.assertEqual(f["features"].attrs.get("encoder"), "uni_v1")
+                    self.assertEqual(f["features"].attrs.get("name"), stem)
+
+            created = [p for p in features_dir.iterdir() if p.suffix == ".h5"]
+            self.assertEqual(len(created), len(expected_stems), "Expected one feature file per WSI")
+
     def test_idempotent_rerun_outputs_unchanged(self):
         import run_batch_of_slides as rbs
 

--- a/trident/Processor.py
+++ b/trident/Processor.py
@@ -210,6 +210,49 @@ class Processor:
             raise
         self._wsi_stack = stack
 
+    def _record_outcome(
+        self,
+        log_fp: str,
+        slide_ref: Dict[str, Any],
+        task: str,
+        status: str,
+        message: str,
+        *,
+        reason: Optional[str] = None,
+        outputs: Optional[Dict[str, Any]] = None,
+        attempt: Optional[Dict[str, Any]] = None,
+        wsi_meta: Optional[Dict[str, Any]] = None,
+        write_log: bool = True,
+    ) -> None:
+        """
+        Record a single task outcome to the per-job text log and the per-slide
+        WSI state from one `message`, so the two records can never drift.
+
+        The tqdm progress line (`set_postfix_str`) is intentionally left to the
+        call site: it is terse, ephemeral progress text, not a persisted record.
+
+        Parameters:
+            write_log: When False, only the WSI state is updated. Used for lock
+                contention, where writing to the shared log would clobber the
+                owning worker's entry. State updates are best-effort and never raise.
+        """
+        if write_log:
+            update_log(log_fp, f"{slide_ref['name']}{slide_ref['ext']}", message)
+        try:
+            update_task_state(
+                self.job_dir,
+                slide_ref,
+                task,
+                status,
+                reason=reason,
+                message=message,
+                outputs=outputs,
+                attempt=attempt,
+                wsi_meta=wsi_meta,
+            )
+        except Exception:
+            pass
+
     def run_segmentation_job(
         self, 
         segmentation_model: torch.nn.Module, 
@@ -280,55 +323,41 @@ class Processor:
             # Check if contour already exists
             if os.path.exists(os.path.join(saveto, f'{wsi.name}.jpg')) and not is_locked(os.path.join(saveto, f'{wsi.name}.jpg')):
                 self.loop.set_postfix_str(f'{wsi.name} already segmented. Skipping...')
-                update_log(os.path.join(self.job_dir, '_logs_segmentation.txt'), f'{wsi.name}{wsi.ext}', 'Tissue segmented.')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        "segmentation",
-                        "skipped",
-                        reason="already_segmented",
-                        outputs={"contour_jpg": os.path.join(saveto, f"{wsi.name}.jpg")},
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    os.path.join(self.job_dir, '_logs_segmentation.txt'),
+                    slide_ref, "segmentation", "skipped",
+                    "Tissue already segmented; skipping.",
+                    reason="already_segmented",
+                    outputs={"contour_jpg": os.path.join(saveto, f"{wsi.name}.jpg")},
+                    wsi_meta=wsi_meta,
+                )
                 continue
 
             # Check if another process has claimed this slide
             if is_locked(os.path.join(saveto, f'{wsi.name}.jpg')):
                 self.loop.set_postfix_str(f'{wsi.name} is locked. Skipping...')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        "segmentation",
-                        "skipped",
-                        reason="locked",
-                        outputs={"contour_jpg": os.path.join(saveto, f"{wsi.name}.jpg")},
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    os.path.join(self.job_dir, '_logs_segmentation.txt'),
+                    slide_ref, "segmentation", "skipped",
+                    "Locked by another worker; skipping.",
+                    reason="locked",
+                    outputs={"contour_jpg": os.path.join(saveto, f"{wsi.name}.jpg")},
+                    wsi_meta=wsi_meta,
+                    write_log=False,
+                )
                 continue
 
             try:
                 self.loop.set_postfix_str(f'Segmenting {wsi}')
                 create_lock(os.path.join(saveto, f'{wsi.name}.jpg'))
-                update_log(os.path.join(self.job_dir, '_logs_segmentation.txt'), f'{wsi.name}{wsi.ext}', 'LOCKED. Segmenting tissue...')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        "segmentation",
-                        "running",
-                        message="started",
-                        outputs={"contour_jpg": os.path.join(saveto, f"{wsi.name}.jpg")},
-                        attempt=make_attempt("started"),
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    os.path.join(self.job_dir, '_logs_segmentation.txt'),
+                    slide_ref, "segmentation", "running",
+                    "Segmenting tissue...",
+                    outputs={"contour_jpg": os.path.join(saveto, f"{wsi.name}.jpg")},
+                    attempt=make_attempt("started"),
+                    wsi_meta=wsi_meta,
+                )
 
                 # call a function from WSI object to do the work
                 gdf_saveto = wsi.segment_tissue(
@@ -341,53 +370,69 @@ class Processor:
                 )
 
                 # additionally remove artifacts for better segmentation.
+                artifact_removal_emptied_tissue = False
                 if artifact_remover_model is not None:
+                    had_tissue_before_artifacts = not gpd.read_file(gdf_saveto, rows=1).empty
                     gdf_saveto = wsi.segment_tissue(
                         segmentation_model=artifact_remover_model,
                         target_mag=artifact_remover_model.target_mag,
                         holes_are_tissue=False,
                         job_dir=self.job_dir
                     )
+                    # Detect the case where artifact removal discarded every tissue
+                    # region the tissue segmenter had found: the slide then silently
+                    # produces no patches/features. Surfaced to the user below.
+                    artifact_removal_emptied_tissue = (
+                        had_tissue_before_artifacts and gpd.read_file(gdf_saveto, rows=1).empty
+                    )
 
                 remove_lock(os.path.join(saveto, f'{wsi.name}.jpg'))
 
                 gdf = gpd.read_file(gdf_saveto, rows=1)
                 if gdf.empty:
-                    update_log(os.path.join(self.job_dir, '_logs_segmentation.txt'), f'{wsi.name}{wsi.ext}', 'Segmentation returned empty GeoDataFrame.')
+                    # Build a single message + reason and reuse it across the console,
+                    # the segmentation log, and the per-slide WSI state.
+                    if artifact_removal_emptied_tissue:
+                        empty_reason = "artifact_removal_emptied_tissue"
+                        empty_msg = (
+                            f"Artifact removal discarded all tissue detected for {wsi.name}{wsi.ext}; "
+                            "this slide will yield no patches or features. Soft/blurry regions (e.g. on "
+                            "downsampled levels of some scanners) can be flagged as out-of-focus artifacts."
+                        )
+                        if not getattr(artifact_remover_model, 'remove_penmarks_only', False):
+                            empty_msg += (
+                                " Re-run with `--remove_penmarks` instead of `--remove_artifacts` for less "
+                                "aggressive removal (pen markings only)."
+                            )
+                    else:
+                        empty_reason = "empty_geodataframe"
+                        empty_msg = "Segmentation returned an empty GeoDataFrame (no tissue detected)."
+                    print(f"[Warning] {empty_msg}")
                     self.loop.set_postfix_str(f'Empty GeoDataFrame for {wsi.name}.')
-                    try:
-                        update_task_state(
-                            self.job_dir,
-                            slide_ref,
-                            "segmentation",
-                            "completed",
-                            reason="empty_geodataframe",
-                            outputs={
-                                "contour_geojson": gdf_saveto,
-                                "contour_jpg": os.path.join(saveto, f"{wsi.name}.jpg"),
-                            },
-                            attempt=make_attempt("finished"),
-                            wsi_meta=wsi_meta,
-                        )
-                    except Exception:
-                        pass
+                    self._record_outcome(
+                        os.path.join(self.job_dir, '_logs_segmentation.txt'),
+                        slide_ref, "segmentation", "completed",
+                        empty_msg,
+                        reason=empty_reason,
+                        outputs={
+                            "contour_geojson": gdf_saveto,
+                            "contour_jpg": os.path.join(saveto, f"{wsi.name}.jpg"),
+                        },
+                        attempt=make_attempt("finished"),
+                        wsi_meta=wsi_meta,
+                    )
                 else:
-                    update_log(os.path.join(self.job_dir,  '_logs_segmentation.txt'), f'{wsi.name}{wsi.ext}', 'Tissue segmented.')
-                    try:
-                        update_task_state(
-                            self.job_dir,
-                            slide_ref,
-                            "segmentation",
-                            "completed",
-                            outputs={
-                                "contour_geojson": gdf_saveto,
-                                "contour_jpg": os.path.join(saveto, f"{wsi.name}.jpg"),
-                            },
-                            attempt=make_attempt("finished"),
-                            wsi_meta=wsi_meta,
-                        )
-                    except Exception:
-                        pass
+                    self._record_outcome(
+                        os.path.join(self.job_dir, '_logs_segmentation.txt'),
+                        slide_ref, "segmentation", "completed",
+                        "Tissue segmented.",
+                        outputs={
+                            "contour_geojson": gdf_saveto,
+                            "contour_jpg": os.path.join(saveto, f"{wsi.name}.jpg"),
+                        },
+                        attempt=make_attempt("finished"),
+                        wsi_meta=wsi_meta,
+                    )
                 
                 # Release WSI resources to prevent memory accumulation
                 wsi.release()
@@ -400,23 +445,17 @@ class Processor:
                 except Exception:
                     pass
                 if self.skip_errors:
-                    update_log(os.path.join(self.job_dir, '_logs_segmentation.txt'), f'{wsi.name}{wsi.ext}', f'ERROR: {e}')
-                    try:
-                        update_task_state(
-                            self.job_dir,
-                            slide_ref,
-                            "segmentation",
-                            "error",
-                            message=str(e),
+                    self._record_outcome(
+                        os.path.join(self.job_dir, '_logs_segmentation.txt'),
+                        slide_ref, "segmentation", "error",
+                        f"ERROR: {e}",
                         attempt=make_attempt("error", error=str(e)),
-                            wsi_meta=wsi_meta,
-                        )
-                    except Exception:
-                        pass
+                        wsi_meta=wsi_meta,
+                    )
                     continue
                 else:
                     raise e
-                
+
         # Return the directory where the contours are saved
         return saveto
 
@@ -523,98 +562,74 @@ class Processor:
             # Check if patch coords already exist
             if os.path.exists(os.path.join(self.job_dir, saveto, 'patches', f'{wsi.name}_patches.h5')):
                 self.loop.set_postfix_str(f'Patch coords already generated for {wsi.name}. Skipping...')
-                update_log(os.path.join(self.job_dir, saveto, '_logs_coords.txt'), f'{wsi.name}{wsi.ext}', 'Coords generated')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        "coords",
-                        "skipped",
-                        reason="already_generated",
-                        outputs={
-                            "coords_h5": os.path.join(self.job_dir, saveto, "patches", f"{wsi.name}_patches.h5")
-                        },
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    os.path.join(self.job_dir, saveto, '_logs_coords.txt'),
+                    slide_ref, "coords", "skipped",
+                    "Patch coords already generated; skipping.",
+                    reason="already_generated",
+                    outputs={
+                        "coords_h5": os.path.join(self.job_dir, saveto, "patches", f"{wsi.name}_patches.h5")
+                    },
+                    wsi_meta=wsi_meta,
+                )
                 continue
-            
+
             # Check if another process has claimed this slide
             if is_locked(os.path.join(self.job_dir, saveto, 'patches', f'{wsi.name}_patches.h5')):
                 self.loop.set_postfix_str(f'{wsi.name} is locked. Skipping...')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        "coords",
-                        "skipped",
-                        reason="locked",
-                        outputs={
-                            "coords_h5": os.path.join(self.job_dir, saveto, "patches", f"{wsi.name}_patches.h5")
-                        },
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    os.path.join(self.job_dir, saveto, '_logs_coords.txt'),
+                    slide_ref, "coords", "skipped",
+                    "Locked by another worker; skipping.",
+                    reason="locked",
+                    outputs={
+                        "coords_h5": os.path.join(self.job_dir, saveto, "patches", f"{wsi.name}_patches.h5")
+                    },
+                    wsi_meta=wsi_meta,
+                    write_log=False,
+                )
                 continue
 
             # Check if segmentation exists
             if wsi.tissue_seg_path is None or not os.path.exists(wsi.tissue_seg_path):
                 self.loop.set_postfix_str(f'GeoJSON not found for {wsi.name}. Skipping...')
-                update_log(os.path.join(self.job_dir, saveto, '_logs_coords.txt'), f'{wsi.name}{wsi.ext}', 'GeoJSON not found.')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        "coords",
-                        "skipped",
-                        reason="geojson_not_found",
-                        outputs={"tissue_geojson": wsi.tissue_seg_path},
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    os.path.join(self.job_dir, saveto, '_logs_coords.txt'),
+                    slide_ref, "coords", "skipped",
+                    "Tissue GeoJSON not found; run segmentation first.",
+                    reason="geojson_not_found",
+                    outputs={"tissue_geojson": wsi.tissue_seg_path},
+                    wsi_meta=wsi_meta,
+                )
                 continue
-            
+
             # Check if GeoJSON is empty
             gdf = gpd.read_file(wsi.tissue_seg_path, rows=1)
             if gdf.empty:
                 self.loop.set_postfix_str(f'Empty GeoDataFrame for {wsi.name}. Skipping...')
-                update_log(os.path.join(self.job_dir, saveto, '_logs_coords.txt'), f'{wsi.name}{wsi.ext}', 'Empty GeoDataFrame.')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        "coords",
-                        "skipped",
-                        reason="empty_geodataframe",
-                        outputs={"tissue_geojson": wsi.tissue_seg_path},
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    os.path.join(self.job_dir, saveto, '_logs_coords.txt'),
+                    slide_ref, "coords", "skipped",
+                    "Tissue GeoDataFrame is empty; no coordinates to extract.",
+                    reason="empty_geodataframe",
+                    outputs={"tissue_geojson": wsi.tissue_seg_path},
+                    wsi_meta=wsi_meta,
+                )
                 continue
 
             try:
                 self.loop.set_postfix_str(f'Generating patch coords for {wsi.name}{wsi.ext}')
-                update_log(os.path.join(self.job_dir, saveto, '_logs_coords.txt'), f'{wsi.name}{wsi.ext}', 'LOCKED. Generating coords...')
                 create_lock(os.path.join(self.job_dir, saveto, 'patches', f'{wsi.name}_patches.h5'))
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        "coords",
-                        "running",
-                        message="started",
-                        outputs={
-                            "coords_h5": os.path.join(self.job_dir, saveto, "patches", f"{wsi.name}_patches.h5")
-                        },
-                        attempt=make_attempt("started"),
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    os.path.join(self.job_dir, saveto, '_logs_coords.txt'),
+                    slide_ref, "coords", "running",
+                    "Generating patch coords...",
+                    outputs={
+                        "coords_h5": os.path.join(self.job_dir, saveto, "patches", f"{wsi.name}_patches.h5")
+                    },
+                    attempt=make_attempt("started"),
+                    wsi_meta=wsi_meta,
+                )
 
                 # save tissue coords
                 wsi.extract_tissue_coords(
@@ -644,22 +659,17 @@ class Processor:
                     )
 
                 remove_lock(os.path.join(self.job_dir, saveto, 'patches', f'{wsi.name}_patches.h5'))
-                update_log(os.path.join(self.job_dir, saveto, '_logs_coords.txt'), f'{wsi.name}{wsi.ext}', 'Coords generated')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        "coords",
-                        "completed",
-                        outputs={
-                            "coords_h5": os.path.join(self.job_dir, saveto, "patches", f"{wsi.name}_patches.h5"),
-                            "coords_viz": os.path.join(self.job_dir, saveto, "visualization", f"{wsi.name}.jpg"),
-                        },
-                        attempt=make_attempt("finished"),
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    os.path.join(self.job_dir, saveto, '_logs_coords.txt'),
+                    slide_ref, "coords", "completed",
+                    "Patch coords generated.",
+                    outputs={
+                        "coords_h5": os.path.join(self.job_dir, saveto, "patches", f"{wsi.name}_patches.h5"),
+                        "coords_viz": os.path.join(self.job_dir, saveto, "visualization", f"{wsi.name}.jpg"),
+                    },
+                    attempt=make_attempt("finished"),
+                    wsi_meta=wsi_meta,
+                )
                 
                 # Release WSI resources to prevent memory accumulation
                 wsi.release()
@@ -672,23 +682,17 @@ class Processor:
                 except Exception:
                     pass
                 if self.skip_errors:
-                    update_log(os.path.join(self.job_dir, saveto, '_logs_coords.txt'), f'{wsi.name}{wsi.ext}', f'ERROR: {e}')
-                    try:
-                        update_task_state(
-                            self.job_dir,
-                            slide_ref,
-                            "coords",
-                            "error",
-                            message=str(e),
-                            attempt=make_attempt("error", error=str(e)),
-                            wsi_meta=wsi_meta,
-                        )
-                    except Exception:
-                        pass
+                    self._record_outcome(
+                        os.path.join(self.job_dir, saveto, '_logs_coords.txt'),
+                        slide_ref, "coords", "error",
+                        f"ERROR: {e}",
+                        attempt=make_attempt("error", error=str(e)),
+                        wsi_meta=wsi_meta,
+                    )
                     continue
                 else:
                     raise e
-        
+
         # Return the directory where the coordinates are saved
         return os.path.join(self.job_dir, saveto)
 
@@ -769,6 +773,7 @@ class Processor:
         )
 
         log_fp = os.path.join(self.job_dir, coords_dir, f'_logs_feats_{patch_encoder.enc_name}.txt')
+        feat_task = f"patch_features:{patch_encoder.enc_name if hasattr(patch_encoder, 'enc_name') else 'encoder'}"
         self.loop = tqdm(self.wsis, desc=f'Extracting patch features from coords in {coords_dir}', total = len(self.wsis))
         for wsi in self.loop:    
             slide_ref = make_slide_ref(
@@ -788,74 +793,51 @@ class Processor:
             # Check if features already exist
             if os.path.exists(wsi_feats_fp) and not is_locked(wsi_feats_fp):
                 self.loop.set_postfix_str(f'Features already extracted for {wsi}. Skipping...')
-                update_log(log_fp, f'{wsi.name}{wsi.ext}', 'Features extracted.')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        f"patch_features:{patch_encoder.enc_name if hasattr(patch_encoder,'enc_name') else 'encoder'}",
-                        "skipped",
-                        reason="already_extracted",
-                        outputs={"features_path": wsi_feats_fp},
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    log_fp, slide_ref, feat_task, "skipped",
+                    "Patch features already extracted; skipping.",
+                    reason="already_extracted",
+                    outputs={"features_path": wsi_feats_fp},
+                    wsi_meta=wsi_meta,
+                )
                 continue
 
             # Check if coords exist
             coords_path = os.path.join(self.job_dir, coords_dir, 'patches', f'{wsi.name}_patches.h5')
             if not os.path.exists(coords_path):
                 self.loop.set_postfix_str(f'Coords not found for {wsi.name}. Skipping...')
-                update_log(log_fp, f'{wsi.name}{wsi.ext}', 'Coords not found.')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        f"patch_features:{patch_encoder.enc_name if hasattr(patch_encoder,'enc_name') else 'encoder'}",
-                        "skipped",
-                        reason="coords_not_found",
-                        outputs={"coords_path": coords_path},
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    log_fp, slide_ref, feat_task, "skipped",
+                    "Patch coords not found; run the coords step first.",
+                    reason="coords_not_found",
+                    outputs={"coords_path": coords_path},
+                    wsi_meta=wsi_meta,
+                )
                 continue
 
             # Check if another process has claimed this slide
             if is_locked(wsi_feats_fp):
                 self.loop.set_postfix_str(f'{wsi.name} is locked. Skipping...')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        f"patch_features:{patch_encoder.enc_name if hasattr(patch_encoder,'enc_name') else 'encoder'}",
-                        "skipped",
-                        reason="locked",
-                        outputs={"features_path": wsi_feats_fp},
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    log_fp, slide_ref, feat_task, "skipped",
+                    "Locked by another worker; skipping.",
+                    reason="locked",
+                    outputs={"features_path": wsi_feats_fp},
+                    wsi_meta=wsi_meta,
+                    write_log=False,
+                )
                 continue
 
             try:
                 self.loop.set_postfix_str(f'Extracting features from {wsi.name}{wsi.ext}')
                 create_lock(wsi_feats_fp)
-                update_log(log_fp, f'{wsi.name}{wsi.ext}', 'LOCKED. Extracting features...')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        f"patch_features:{patch_encoder.enc_name if hasattr(patch_encoder,'enc_name') else 'encoder'}",
-                        "running",
-                        message="started",
-                        outputs={"features_path": wsi_feats_fp, "coords_path": coords_path},
-                        attempt=make_attempt("started"),
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    log_fp, slide_ref, feat_task, "running",
+                    "Extracting patch features...",
+                    outputs={"features_path": wsi_feats_fp, "coords_path": coords_path},
+                    attempt=make_attempt("started"),
+                    wsi_meta=wsi_meta,
+                )
 
                 wsi.extract_patch_features(
                     patch_encoder = patch_encoder,
@@ -867,20 +849,14 @@ class Processor:
                 )
 
                 remove_lock(wsi_feats_fp)
-                update_log(log_fp, f'{wsi.name}{wsi.ext}', 'Features extracted.')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        f"patch_features:{patch_encoder.enc_name if hasattr(patch_encoder,'enc_name') else 'encoder'}",
-                        "completed",
-                        outputs={"features_path": wsi_feats_fp, "coords_path": coords_path},
-                        attempt=make_attempt("finished"),
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
-                
+                self._record_outcome(
+                    log_fp, slide_ref, feat_task, "completed",
+                    "Patch features extracted.",
+                    outputs={"features_path": wsi_feats_fp, "coords_path": coords_path},
+                    attempt=make_attempt("finished"),
+                    wsi_meta=wsi_meta,
+                )
+
                 # Release WSI resources to prevent memory accumulation
                 wsi.release()
             except Exception as e:
@@ -892,23 +868,16 @@ class Processor:
                 except Exception:
                     pass
                 if self.skip_errors:
-                    update_log(log_fp, f'{wsi.name}{wsi.ext}', f'ERROR: {e}')
-                    try:
-                        update_task_state(
-                            self.job_dir,
-                            slide_ref,
-                            f"patch_features:{patch_encoder.enc_name if hasattr(patch_encoder,'enc_name') else 'encoder'}",
-                            "error",
-                            message=str(e),
-                            attempt=make_attempt("error", error=str(e)),
-                            wsi_meta=wsi_meta,
-                        )
-                    except Exception:
-                        pass
+                    self._record_outcome(
+                        log_fp, slide_ref, feat_task, "error",
+                        f"ERROR: {e}",
+                        attempt=make_attempt("error", error=str(e)),
+                        wsi_meta=wsi_meta,
+                    )
                     continue
                 else:
                     raise e
-        
+
         # Return the directory where the features are saved
         return os.path.join(self.job_dir, saveto)
 
@@ -999,6 +968,8 @@ class Processor:
             ignore=['loop', 'valid_slides', 'wsis']
         )
 
+        slide_feat_log_fp = os.path.join(self.job_dir, coords_dir, f'_logs_slide_features_{slide_encoder.enc_name}.txt')
+        slide_feat_task = f"slide_features:{slide_encoder.enc_name}"
         self.loop = tqdm(self.wsis, desc=f'Extracting slide features using {slide_encoder.enc_name}', total=len(self.wsis))
         for wsi in self.loop:
             slide_ref = make_slide_ref(
@@ -1018,77 +989,54 @@ class Processor:
             slide_feature_path = os.path.join(self.job_dir, saveto, f'{wsi.name}.{saveas}')
             if os.path.exists(slide_feature_path) and not is_locked(slide_feature_path):
                 self.loop.set_postfix_str(f'Slide features already extracted for {wsi.name}. Skipping...')
-                update_log(os.path.join(self.job_dir, coords_dir, f'_logs_slide_features_{slide_encoder.enc_name}.txt'), f'{wsi.name}{wsi.ext}', 'Slide features extracted.')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        f"slide_features:{slide_encoder.enc_name}",
-                        "skipped",
-                        reason="already_extracted",
-                        outputs={"slide_features_path": slide_feature_path},
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    slide_feat_log_fp, slide_ref, slide_feat_task, "skipped",
+                    "Slide features already extracted; skipping.",
+                    reason="already_extracted",
+                    outputs={"slide_features_path": slide_feature_path},
+                    wsi_meta=wsi_meta,
+                )
                 continue
 
             # Check if patch features exist
             patch_features_path = os.path.join(self.job_dir, patch_features_dir, f'{wsi.name}.h5')
             if not os.path.exists(patch_features_path):
                 self.loop.set_postfix_str(f'Patch features not found for {wsi.name}. Skipping...')
-                update_log(os.path.join(self.job_dir, coords_dir, f'_logs_slide_features_{slide_encoder.enc_name}.txt'), f'{wsi.name}{wsi.ext}', 'Patch features not found.')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        f"slide_features:{slide_encoder.enc_name}",
-                        "skipped",
-                        reason="patch_features_not_found",
-                        outputs={"patch_features_path": patch_features_path},
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    slide_feat_log_fp, slide_ref, slide_feat_task, "skipped",
+                    "Patch features not found; run the patch-feature step first.",
+                    reason="patch_features_not_found",
+                    outputs={"patch_features_path": patch_features_path},
+                    wsi_meta=wsi_meta,
+                )
                 continue
 
             # Check if another process has claimed this slide
             if is_locked(slide_feature_path):
                 self.loop.set_postfix_str(f'{wsi.name} is locked. Skipping...')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        f"slide_features:{slide_encoder.enc_name}",
-                        "skipped",
-                        reason="locked",
-                        outputs={"slide_features_path": slide_feature_path},
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    slide_feat_log_fp, slide_ref, slide_feat_task, "skipped",
+                    "Locked by another worker; skipping.",
+                    reason="locked",
+                    outputs={"slide_features_path": slide_feature_path},
+                    wsi_meta=wsi_meta,
+                    write_log=False,
+                )
                 continue
 
             try:
                 self.loop.set_postfix_str(f'Extracting slide features for {wsi.name}{wsi.ext}')
                 create_lock(slide_feature_path)
-                update_log(os.path.join(self.job_dir, coords_dir, f'_logs_slide_features_{slide_encoder.enc_name}.txt'), f'{wsi.name}{wsi.ext}', 'LOCKED. Extracting slide features...')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        f"slide_features:{slide_encoder.enc_name}",
-                        "running",
-                        message="started",
-                        outputs={
-                            "slide_features_path": slide_feature_path,
-                            "patch_features_path": patch_features_path,
-                        },
-                        attempt=make_attempt("started"),
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
+                self._record_outcome(
+                    slide_feat_log_fp, slide_ref, slide_feat_task, "running",
+                    "Extracting slide features...",
+                    outputs={
+                        "slide_features_path": slide_feature_path,
+                        "patch_features_path": patch_features_path,
+                    },
+                    attempt=make_attempt("started"),
+                    wsi_meta=wsi_meta,
+                )
 
                 # Call the extract_slide_features method
                 wsi.extract_slide_features(
@@ -1099,23 +1047,17 @@ class Processor:
                 )
 
                 remove_lock(slide_feature_path)
-                update_log(os.path.join(self.job_dir, coords_dir, f'_logs_slide_features_{slide_encoder.enc_name}.txt'), f'{wsi.name}{wsi.ext}', 'Slide features extracted.')
-                try:
-                    update_task_state(
-                        self.job_dir,
-                        slide_ref,
-                        f"slide_features:{slide_encoder.enc_name}",
-                        "completed",
-                        outputs={
-                            "slide_features_path": slide_feature_path,
-                            "patch_features_path": patch_features_path,
-                        },
-                        attempt=make_attempt("finished"),
-                        wsi_meta=wsi_meta,
-                    )
-                except Exception:
-                    pass
-                
+                self._record_outcome(
+                    slide_feat_log_fp, slide_ref, slide_feat_task, "completed",
+                    "Slide features extracted.",
+                    outputs={
+                        "slide_features_path": slide_feature_path,
+                        "patch_features_path": patch_features_path,
+                    },
+                    attempt=make_attempt("finished"),
+                    wsi_meta=wsi_meta,
+                )
+
                 # Release WSI resources to prevent memory accumulation
                 wsi.release()
             except Exception as e:
@@ -1127,19 +1069,12 @@ class Processor:
                 except Exception:
                     pass
                 if self.skip_errors:
-                    update_log(os.path.join(self.job_dir, coords_dir, f'_logs_slide_features_{slide_encoder.enc_name}.txt'), f'{wsi.name}{wsi.ext}', f'ERROR: {e}')
-                    try:
-                        update_task_state(
-                            self.job_dir,
-                            slide_ref,
-                            f"slide_features:{slide_encoder.enc_name}",
-                            "error",
-                            message=str(e),
-                            attempt=make_attempt("error", error=str(e)),
-                            wsi_meta=wsi_meta,
-                        )
-                    except Exception:
-                        pass
+                    self._record_outcome(
+                        slide_feat_log_fp, slide_ref, slide_feat_task, "error",
+                        f"ERROR: {e}",
+                        attempt=make_attempt("error", error=str(e)),
+                        wsi_meta=wsi_meta,
+                    )
                     continue
                 else:
                     raise e


### PR DESCRIPTION
Adds MRXS (MIRAX) test coverage and fixes a silent failure where --remove_artifacts could leave a slide with no patches or features, with no explanation.

While testing MRXS support, we found that running --task all with --remove_artifacts on a MIRAX slide (CMU-1) produced zero patches/features.

Root cause: GrandQC's artifact model reads the tiles as out-of-focus (OOF). The identical image as a single-file .tiff survives fine (focus ~1230 vs ~390 for the MRXS level). It's an over-sensitive OOF classification.